### PR TITLE
Support PAT to trigger GitHub Actions after auto-merge

### DIFF
--- a/.github/workflows/auto-update-pr.yml
+++ b/.github/workflows/auto-update-pr.yml
@@ -1,5 +1,16 @@
 name: Auto Update PR Branches
 
+# IMPORTANT: To trigger PR checks after auto-merge, create a PAT with 'repo' scope
+# and add it as a repository secret named 'PAT_TOKEN'. Without it, the default
+# GITHUB_TOKEN will be used but won't trigger workflows (to prevent infinite loops).
+#
+# Steps to set up PAT:
+# 1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+# 2. Generate new token with 'repo' scope
+# 3. Add as repository secret: Settings → Secrets → Actions → New repository secret
+#    - Name: PAT_TOKEN
+#    - Value: your generated token
+
 on:
   push:
     branches:
@@ -16,12 +27,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: true
 
       - name: Update PR branches
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
         run: |
           # Configure git user for commits
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Problem

The auto-update workflow successfully merges main into PR branches, but **GitHub Actions checks don't trigger** on the updated PRs.

**Why?** When using the default \, GitHub intentionally doesn't trigger workflows to prevent infinite loops. This is a security feature.

**Impact:** Auto-merged PRs show outdated check results and require manual re-triggering.

## Solution

Support an optional **Personal Access Token (PAT)** that will trigger GitHub Actions:

\
**Benefits:**
- ✅ When PAT is configured: Auto-merged PRs trigger checks automatically
- ✅ Without PAT: Workflow still works (just doesn't trigger checks)
- ✅ No breaking changes - backward compatible

## How to Enable (Optional)

To make auto-merged PRs trigger GitHub Actions checks:

### 1. Create a Personal Access Token

1. Go to [GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens)
2. Click **Generate new token (classic)**
3. Set expiration and select **\** scope
4. Generate and copy the token

### 2. Add as Repository Secret

1. Go to [Repository Settings → Secrets and variables → Actions](https://github.com/etiennechabert/terraform-aws-sp-autopilot/settings/secrets/actions)
2. Click **New repository secret**
3. Name: 4. Value: paste your token
5. Click **Add secret**

### 3. That's it\!

The workflow will automatically use the PAT on the next push to main.

## Changes Made

- ✅ Support optional \ secret
- ✅ Fallback to \ if PAT not configured
- ✅ Add detailed setup instructions in workflow comments
- ✅ No breaking changes

## Testing

- [x] Workflow syntax valid
- [x] Works without PAT (current behavior)
- [ ] Test with PAT to verify checks trigger
- [ ] Verify auto-merged PRs show updated checks

## Related

- Issue: Auto-update works but doesn't trigger GitHub Actions
- Docs: [GitHub Actions triggering workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)