### PR TITLE
Add VSCode debug configurations for local Lambda development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,77 @@
+# AWS Credentials (for local debugging)
+# Copy this file to .env and fill in your values
+# Never commit .env to version control!
+
+AWS_REGION=us-east-1
+AWS_DEFAULT_REGION=us-east-1
+AWS_PROFILE=default
+
+# Optional: If not using AWS CLI profile, set credentials directly
+# AWS_ACCESS_KEY_ID=your-access-key-here
+# AWS_SECRET_ACCESS_KEY=your-secret-key-here
+
+# ============================================================================
+# Scheduler Lambda Environment Variables
+# ============================================================================
+
+# SQS Queue URL for purchase intents
+QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/sp-autopilot-purchase-intents
+
+# SNS Topic ARN for notifications
+SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:sp-autopilot-notifications
+
+# Dry run mode (true = no actual purchases, only email notifications)
+DRY_RUN=true
+
+# Enable/disable Savings Plan types
+ENABLE_COMPUTE_SP=true
+ENABLE_SAGEMAKER_SP=false
+
+# Coverage targets
+COVERAGE_TARGET_PERCENT=90
+MAX_COVERAGE_CAP=95
+
+# Purchase strategy
+PURCHASE_STRATEGY_TYPE=simple
+SIMPLE_MAX_PURCHASE_PERCENT=10
+
+# Compute SP term mix (must sum to ~1.0)
+COMPUTE_SP_TERM_MIX_THREE_YEAR=0.3
+COMPUTE_SP_TERM_MIX_ONE_YEAR=0.7
+
+# SageMaker SP term mix (optional, only if ENABLE_SAGEMAKER_SP=true)
+# SAGEMAKER_SP_TERM_MIX_THREE_YEAR=0.5
+# SAGEMAKER_SP_TERM_MIX_ONE_YEAR=0.5
+
+# Plan renewal settings
+RENEWAL_WINDOW_DAYS=7
+MIN_COMMITMENT_PER_PLAN=0
+
+# Payment options
+COMPUTE_SP_PAYMENT_OPTION=NO_UPFRONT
+# SAGEMAKER_SP_PAYMENT_OPTION=NO_UPFRONT
+
+# ============================================================================
+# Purchaser Lambda Environment Variables
+# ============================================================================
+
+# (Uses same QUEUE_URL, SNS_TOPIC_ARN, DRY_RUN, MAX_COVERAGE_CAP from above)
+
+# ============================================================================
+# Reporter Lambda Environment Variables
+# ============================================================================
+
+# S3 bucket for reports
+REPORTS_BUCKET=sp-autopilot-reports-123456789012
+
+# Report settings
+REPORT_FORMAT=html
+EMAIL_REPORTS=false
+LOW_UTILIZATION_THRESHOLD=70
+
+# Optional: Management account role for cross-account reporting
+# MANAGEMENT_ACCOUNT_ROLE_ARN=arn:aws:iam::123456789012:role/SPAutopilotReporterRole
+
+# Optional: Webhook notifications
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+# TEAMS_WEBHOOK_URL=https://outlook.office.com/webhook/YOUR/WEBHOOK/URL

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,162 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Scheduler Lambda",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "lambda.scheduler.handler",
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                // Required environment variables
+                "QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+                "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                "DRY_RUN": "true",
+                "ENABLE_COMPUTE_SP": "true",
+                "ENABLE_SAGEMAKER_SP": "false",
+                "COVERAGE_TARGET_PERCENT": "90",
+                "MAX_COVERAGE_CAP": "95",
+                "PURCHASE_STRATEGY_TYPE": "simple",
+                "SIMPLE_MAX_PURCHASE_PERCENT": "10",
+                "COMPUTE_SP_TERM_MIX_THREE_YEAR": "0.3",
+                "COMPUTE_SP_TERM_MIX_ONE_YEAR": "0.7",
+                "RENEWAL_WINDOW_DAYS": "7",
+                "MIN_COMMITMENT_PER_PLAN": "0",
+                "COMPUTE_SP_PAYMENT_OPTION": "NO_UPFRONT"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/scheduler"
+        },
+        {
+            "name": "Debug Purchaser Lambda",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "lambda.purchaser.handler",
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                // Required environment variables
+                "QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+                "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                "DRY_RUN": "true",
+                "MAX_COVERAGE_CAP": "95"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/purchaser"
+        },
+        {
+            "name": "Debug Reporter Lambda",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "lambda.reporter.handler",
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                // Required environment variables
+                "REPORTS_BUCKET": "test-reports-bucket",
+                "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                "REPORT_FORMAT": "html",
+                "EMAIL_REPORTS": "false",
+                "LOW_UTILIZATION_THRESHOLD": "70"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/reporter"
+        },
+        {
+            "name": "Debug Local Mode Runner",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/lambda/shared/local_runner.py",
+            "args": [
+                "scheduler"
+            ],
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1",
+                "AWS_DEFAULT_REGION": "us-east-1"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Run Scheduler Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "tests/",
+                "-v",
+                "--no-cov"
+            ],
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/scheduler"
+        },
+        {
+            "name": "Run Purchaser Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "tests/",
+                "-v",
+                "--no-cov"
+            ],
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/purchaser"
+        },
+        {
+            "name": "Run Reporter Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "tests/",
+                "-v",
+                "--no-cov"
+            ],
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/reporter"
+        },
+        {
+            "name": "Run Shared Module Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "tests/",
+                "-v",
+                "--no-cov"
+            ],
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "AWS_REGION": "us-east-1"
+            },
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/lambda/shared"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,47 @@
+{
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": [
+        "--no-cov",
+        "-v"
+    ],
+    "python.envFile": "${workspaceFolder}/.env",
+    "python.analysis.extraPaths": [
+        "${workspaceFolder}/lambda/scheduler",
+        "${workspaceFolder}/lambda/purchaser",
+        "${workspaceFolder}/lambda/reporter",
+        "${workspaceFolder}/lambda/shared"
+    ],
+    "python.analysis.typeCheckingMode": "basic",
+    "python.linting.enabled": true,
+    "python.linting.ruffEnabled": true,
+    "python.formatting.provider": "none",
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+        }
+    },
+    "files.exclude": {
+        "**/__pycache__": true,
+        "**/.pytest_cache": true,
+        "**/*.pyc": true,
+        "**/.coverage": true,
+        "**/htmlcov": true,
+        "**/.terraform": true,
+        "**/.terraform.lock.hcl": false
+    },
+    "search.exclude": {
+        "**/__pycache__": true,
+        "**/.pytest_cache": true,
+        "**/.terraform": true,
+        "**/htmlcov": true
+    },
+    "files.watcherExclude": {
+        "**/__pycache__": true,
+        "**/.pytest_cache": true,
+        "**/.terraform/**": true
+    }
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,240 @@
+# Development Guide
+
+This guide explains how to set up your local development environment for debugging and testing the Lambda functions.
+
+## Prerequisites
+
+- Python 3.11
+- VSCode with Python extension
+- AWS CLI configured with credentials
+- ruff (Python linter/formatter)
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+# Install dependencies for each Lambda function
+cd lambda/scheduler && pip install -r requirements.txt
+cd ../purchaser && pip install -r requirements.txt
+cd ../reporter && pip install -r requirements.txt
+cd ../shared && pip install -r requirements.txt
+```
+
+### 2. Configure AWS Credentials
+
+Create a `.env` file in the project root:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and add your AWS credentials and test resource ARNs.
+
+### 3. VSCode Debugging
+
+The project includes pre-configured VSCode launch configurations:
+
+#### Debug Lambda Functions
+
+- **Debug Scheduler Lambda** - Debug the scheduler Lambda handler
+- **Debug Purchaser Lambda** - Debug the purchaser Lambda handler
+- **Debug Reporter Lambda** - Debug the reporter Lambda handler
+- **Debug Local Mode Runner** - Run Lambda functions locally using the local_runner.py utility
+
+#### Run Tests
+
+- **Run Scheduler Tests** - Run scheduler Lambda unit tests
+- **Run Purchaser Tests** - Run purchaser Lambda unit tests
+- **Run Reporter Tests** - Run reporter Lambda unit tests
+- **Run Shared Module Tests** - Run shared module tests
+
+### 4. Using the Debugger
+
+1. Open VSCode
+2. Press `F5` or go to Run → Start Debugging
+3. Select a configuration from the dropdown
+4. Set breakpoints in your code
+5. The debugger will stop at breakpoints
+
+## Local Lambda Execution
+
+### Using local_runner.py
+
+The `local_runner.py` utility simulates AWS Lambda execution locally:
+
+```bash
+# Run scheduler locally
+python lambda/shared/local_runner.py scheduler
+
+# Run purchaser locally
+python lambda/shared/local_runner.py purchaser
+
+# Run reporter locally
+python lambda/shared/local_runner.py reporter
+```
+
+This reads environment variables from `.env` and executes the Lambda handler with mock AWS context.
+
+### Testing with Real AWS Resources
+
+To test with real AWS infrastructure:
+
+1. Deploy the Terraform module to a test AWS account
+2. Update `.env` with the actual resource ARNs (SQS queue, SNS topic, S3 bucket)
+3. **Keep `DRY_RUN=true`** to prevent actual Savings Plans purchases
+4. Run the Lambda functions locally
+
+## Running Tests
+
+### Unit Tests
+
+```bash
+# Run all tests for a Lambda function
+cd lambda/scheduler
+pytest tests/ -v
+
+# Run specific test file
+pytest tests/test_handler.py -v
+
+# Run specific test
+pytest tests/test_handler.py::test_handler_success -v
+
+# Run with coverage
+pytest tests/ -v --cov=. --cov-report=html
+```
+
+### Integration Tests
+
+```bash
+cd terraform-tests/integration
+
+# Run all integration tests
+go test -v -timeout 30m
+
+# Run specific test
+go test -v -run TestFullDeploymentAndCleanup
+```
+
+## Code Quality
+
+### Linting and Formatting
+
+```bash
+# Check code quality
+ruff check lambda/
+
+# Fix auto-fixable issues
+ruff check lambda/ --fix
+
+# Format code
+ruff format lambda/
+
+# Check formatting without changes
+ruff format lambda/ --check
+```
+
+VSCode is configured to auto-format on save using ruff.
+
+## Common Tasks
+
+### Adding a New Feature
+
+1. Create a feature branch
+2. Add your code changes
+3. Add unit tests
+4. Run tests locally: `pytest tests/ -v`
+5. Run linting: `ruff check . && ruff format --check .`
+6. Test with debugger in VSCode
+7. Commit and push
+
+### Debugging a Failing Test
+
+1. Set breakpoint in test file
+2. Use "Run Scheduler Tests" (or other) configuration
+3. VSCode will stop at breakpoint
+4. Inspect variables and step through code
+
+### Testing Coverage Calculation
+
+1. Use "Debug Scheduler Lambda" configuration
+2. Set breakpoint in `coverage_calculator.py`
+3. Mock boto3 clients will be used (from tests)
+4. Or use real AWS credentials to test against real data
+
+### Testing Purchase Logic
+
+1. **IMPORTANT:** Always keep `DRY_RUN=true` in `.env`
+2. Use "Debug Purchaser Lambda" configuration
+3. Set breakpoints in `handler.py`
+4. Inspect purchase intent messages from SQS
+
+## Environment Variables Reference
+
+See `.env.example` for all available environment variables with descriptions.
+
+### Critical Variables
+
+- `DRY_RUN` - **ALWAYS** set to `true` for local testing
+- `QUEUE_URL` - SQS queue URL for purchase intents
+- `SNS_TOPIC_ARN` - SNS topic for notifications
+- `REPORTS_BUCKET` - S3 bucket for reports (reporter only)
+
+### Coverage Configuration
+
+- `COVERAGE_TARGET_PERCENT` - Target coverage percentage (default: 90)
+- `MAX_COVERAGE_CAP` - Hard limit on coverage (default: 95)
+- `ENABLE_COMPUTE_SP` - Enable Compute Savings Plans (default: true)
+- `ENABLE_SAGEMAKER_SP` - Enable SageMaker Savings Plans (default: false)
+
+## Troubleshooting
+
+### Import Errors
+
+If you get import errors, ensure `PYTHONPATH` includes the project root:
+
+```bash
+export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+```
+
+VSCode launch configurations already set this.
+
+### AWS Credentials Not Found
+
+Ensure your AWS credentials are configured:
+
+```bash
+aws configure
+# OR
+export AWS_PROFILE=your-profile-name
+```
+
+### Boto3 Type Stubs Not Found
+
+Install boto3 type stubs:
+
+```bash
+pip install 'boto3-stubs[ce,savingsplans,sns,sqs,s3]'
+```
+
+### Coverage Data Not Available
+
+This is normal for new AWS accounts. Cost Explorer needs 24-48 hours of usage data. The Lambda functions handle this gracefully by returning 0% coverage.
+
+## CI/CD
+
+The project uses GitHub Actions for CI:
+
+- **Python Linting** - Ruff check and format validation
+- **Lambda Tests** - Unit tests for scheduler, purchaser, reporter
+- **Terraform Unit Tests** - Mock-based Terraform tests
+- **Terraform Integration Tests** - Real AWS infrastructure tests
+
+All checks must pass before merging PRs.
+
+## Resources
+
+- [AWS Savings Plans Documentation](https://docs.aws.amazon.com/savingsplans/)
+- [Cost Explorer API Reference](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Operations_AWS_Cost_Explorer_Service.html)
+- [VSCode Python Debugging](https://code.visualstudio.com/docs/python/debugging)
+- [pytest Documentation](https://docs.pytest.org/)


### PR DESCRIPTION
## Summary
- Add VSCode launch configurations for debugging all Lambda functions
- Add VSCode settings for Python development with pytest and ruff
- Add comprehensive `.env.example` with all environment variables
- Add `DEVELOPMENT.md` guide for local development setup

## Debug Configurations
### Lambda Debuggers
- Debug Scheduler Lambda - Run scheduler handler with breakpoints
- Debug Purchaser Lambda - Run purchaser handler with breakpoints  
- Debug Reporter Lambda - Run reporter handler with breakpoints
- Debug Local Mode Runner - Run local_runner.py utility

### Test Runners
- Run Scheduler Tests - Execute scheduler pytest suite
- Run Purchaser Tests - Execute purchaser pytest suite
- Run Reporter Tests - Execute reporter pytest suite
- Run Shared Module Tests - Execute shared module pytest suite

## Developer Experience Improvements
- Auto-format on save with ruff
- PYTHONPATH pre-configured for all Lambda modules
- Environment variables templated in `.env.example`
- Complete development guide with setup, debugging, and testing instructions

## Test plan
- [x] VSCode launch configurations created
- [x] Settings configured for Python/pytest/ruff
- [x] Environment variable template documented
- [x] Development guide written
- [ ] Test debug configurations in VSCode
- [ ] Verify pytest runs work from VSCode UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)