### PR TITLE
Enable codecov updates on main branch pushes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - develop
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Added `push` trigger to pr-checks workflow for main branch
- Ensures codecov receives coverage updates after PR merges

## Problem
Codecov's last known commit was e689fa8 (PR #31 from months ago) because the pr-checks workflow only ran on `pull_request` events. When PRs merged to main, no workflow ran to upload coverage, leaving codecov with stale data.

## Solution
Added push trigger:
```yaml
on:
  pull_request:
    branches:
      - main
      - develop
  push:
    branches:
      - main  # NEW: runs on merge to main
  workflow_dispatch:
```

Now when PRs merge to main:
1. The pr-checks workflow runs automatically
2. All Lambda tests execute and generate coverage
3. Coverage is uploaded to codecov with the main branch commit hash
4. Codecov stays up-to-date with the latest main branch coverage

## Test Plan
- [x] Workflow configuration is valid
- [ ] After merge, codecov will update with latest main commit
- [ ] Shared folder coverage will appear in codecov reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)