### PR TITLE
Add import validation tests and dead code detection guidance

### DIFF
--- a/lambda/purchaser/tests/test_handler_import.py
+++ b/lambda/purchaser/tests/test_handler_import.py
@@ -1,0 +1,34 @@
+"""
+Import validation test for Purchaser Lambda handler.
+
+This test verifies the handler module can be imported successfully,
+catching import errors before deployment to AWS Lambda.
+"""
+
+import sys
+from pathlib import Path
+
+
+def test_handler_module_can_be_imported():
+    """
+    Test that handler module imports successfully without errors.
+
+    This test catches:
+    - Missing dependencies
+    - Circular imports
+    - Invalid import statements (wrong module paths)
+    - ModuleNotFoundError errors
+
+    Per TESTING.md: Run this test FIRST - if handler can't import, nothing else matters.
+    """
+    # Ensure lambda directory is in path
+    lambda_dir = Path(__file__).parent.parent
+    if str(lambda_dir) not in sys.path:
+        sys.path.insert(0, str(lambda_dir))
+
+    # This should work without errors
+    import handler
+
+    # Verify handler function exists and is callable
+    assert hasattr(handler, "handler"), "Handler module missing 'handler' function"
+    assert callable(handler.handler), "handler.handler is not callable"

--- a/lambda/reporter/tests/test_handler_import.py
+++ b/lambda/reporter/tests/test_handler_import.py
@@ -1,0 +1,34 @@
+"""
+Import validation test for Reporter Lambda handler.
+
+This test verifies the handler module can be imported successfully,
+catching import errors before deployment to AWS Lambda.
+"""
+
+import sys
+from pathlib import Path
+
+
+def test_handler_module_can_be_imported():
+    """
+    Test that handler module imports successfully without errors.
+
+    This test catches:
+    - Missing dependencies
+    - Circular imports
+    - Invalid import statements (wrong module paths)
+    - ModuleNotFoundError errors
+
+    Per TESTING.md: Run this test FIRST - if handler can't import, nothing else matters.
+    """
+    # Ensure lambda directory is in path
+    lambda_dir = Path(__file__).parent.parent
+    if str(lambda_dir) not in sys.path:
+        sys.path.insert(0, str(lambda_dir))
+
+    # This should work without errors
+    import handler
+
+    # Verify handler function exists and is callable
+    assert hasattr(handler, "handler"), "Handler module missing 'handler' function"
+    assert callable(handler.handler), "handler.handler is not callable"

--- a/lambda/scheduler/tests/test_handler_import.py
+++ b/lambda/scheduler/tests/test_handler_import.py
@@ -1,0 +1,34 @@
+"""
+Import validation test for Scheduler Lambda handler.
+
+This test verifies the handler module can be imported successfully,
+catching import errors before deployment to AWS Lambda.
+"""
+
+import sys
+from pathlib import Path
+
+
+def test_handler_module_can_be_imported():
+    """
+    Test that handler module imports successfully without errors.
+
+    This test catches:
+    - Missing dependencies
+    - Circular imports
+    - Invalid import statements (wrong module paths)
+    - ModuleNotFoundError errors
+
+    Per TESTING.md: Run this test FIRST - if handler can't import, nothing else matters.
+    """
+    # Ensure lambda directory is in path
+    lambda_dir = Path(__file__).parent.parent
+    if str(lambda_dir) not in sys.path:
+        sys.path.insert(0, str(lambda_dir))
+
+    # This should work without errors
+    import handler
+
+    # Verify handler function exists and is callable
+    assert hasattr(handler, "handler"), "Handler module missing 'handler' function"
+    assert callable(handler.handler), "handler.handler is not callable"


### PR DESCRIPTION
## Summary

Add mandatory import smoke tests for all 3 Lambda handlers to catch deployment errors before they reach production.

Fixes issues discovered in PR #108 where we spent hours debugging dead code that broke SonarCloud.

## Changes

### New Test Files
- ✅ `lambda/scheduler/tests/test_handler_import.py`
- ✅ `lambda/purchaser/tests/test_handler_import.py`
- ✅ `lambda/reporter/tests/test_handler_import.py`

Each test verifies:
- Handler module can be imported without errors
- No `ModuleNotFoundError`, circular imports, or invalid import paths
- Handler function exists and is callable

### TESTING.md Updates

1. **Added "Import Validation" as mandatory test scenario #0**
   - Runs first (alphabetically before other test files)
   - Catches import errors that tests with sys.path manipulation miss
   - Real example: PR #108 `"No module named 'optimal_coverage'"` error

2. **Expanded "Dead Code Detection" section**
   - Shell command to find dead code files in Lambda directories
   - Real examples from PR #108 (669 lines of dead code)
   - Prevention tips for contributors

3. **Updated Quick Validation Checklist**
   - Added requirement for `test_handler_import.py`

4. **Updated Reference Implementations table**
   - Documents all 3 new import validation tests

## Why This Matters

In PR #108, we refactored **669 lines of dead code** that were never imported:
- `alerts.py` (121 lines) - Handler used `notifications.py` instead
- `html_report.py` (406 lines) - Handler used `report_generator.py` instead
- `test_alerts.py` (142 lines) - Tested the dead code

**Impact:**
- ❌ SonarCloud flagged 0% coverage on "new code" 
- ❌ Hours spent debugging why tests passed but coverage failed
- ❌ Wasted refactoring effort on unused files

**These tests prevent this from happening again.**

## How Import Validation Works

```python
def test_handler_module_can_be_imported():
    """Verify handler imports without errors."""
    import handler
    assert hasattr(handler, "handler")
    assert callable(handler.handler)
```

**What it catches:**
- Missing dependencies
- Circular imports
- Wrong import paths (`from optimal_coverage` vs `from shared.optimal_coverage`)
- ModuleNotFoundError before deployment

## Testing

All 3 new tests pass:
```bash
✓ lambda/scheduler/tests/test_handler_import.py::test_handler_module_can_be_imported
✓ lambda/purchaser/tests/test_handler_import.py::test_handler_module_can_be_imported
✓ lambda/reporter/tests/test_handler_import.py::test_handler_module_can_be_imported
```

## Checklist

- [x] Import validation tests added for all 3 Lambdas
- [x] TESTING.md updated with new requirements
- [x] Dead code detection guidance documented
- [x] Tests pass locally
- [x] Linting passes

## Related

- Fixes issues from PR #108
- Prevents future import errors in Lambda runtime
- Improves contributor experience with clear dead code detection