### PR TITLE
Fix reporter Lambda missing scheduler_preview module

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -300,6 +300,28 @@ data "archive_file" "reporter" {
     content  = file("${path.module}/lambda/reporter/notifications.py")
     filename = "notifications.py"
   }
+  source {
+    content  = file("${path.module}/lambda/reporter/scheduler_preview.py")
+    filename = "scheduler_preview.py"
+  }
+
+  # Include scheduler strategy modules (needed by scheduler_preview.py)
+  source {
+    content  = file("${path.module}/lambda/scheduler/fixed_strategy.py")
+    filename = "fixed_strategy.py"
+  }
+  source {
+    content  = file("${path.module}/lambda/scheduler/dichotomy_strategy.py")
+    filename = "dichotomy_strategy.py"
+  }
+  source {
+    content  = file("${path.module}/lambda/scheduler/follow_aws_strategy.py")
+    filename = "follow_aws_strategy.py"
+  }
+  source {
+    content  = file("${path.module}/lambda/scheduler/recommendations.py")
+    filename = "recommendations.py"
+  }
 
   # Include shared module
   source {


### PR DESCRIPTION
## Summary
- Fixes Runtime.ImportModuleError: "No module named 'scheduler_preview'" in reporter Lambda
- Adds scheduler_preview.py and its dependencies to the reporter Lambda deployment package

## Changes
Added the following modules to the reporter Lambda package in lambda.tf:
- `scheduler_preview.py` - imported by handler.py but was missing from package
- `fixed_strategy.py` - required by scheduler_preview
- `dichotomy_strategy.py` - required by scheduler_preview
- `follow_aws_strategy.py` - required by scheduler_preview
- `recommendations.py` - required by follow_aws_strategy

## Test plan
- [ ] Deploy with `terraform apply`
- [ ] Verify reporter Lambda executes without import errors
- [ ] Confirm scheduler preview data appears in reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)