### PR TITLE
Change email_reports default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ module "savings_plans" {
     emails = ["devops@example.com"]
   }
 
+  # Reporting is optional - reports are stored in S3 and emailed by default
+  # reporting = {
+  #   email_reports = false # Set to false to only store in S3 without email
+  # }
+
   lambda_config = {
     scheduler = { dry_run = true } # Start in dry-run mode (recommended)
   }
@@ -237,6 +242,22 @@ notifications = {
 ```
 
 **Security:** Always mark webhook URLs as `sensitive = true` and store in AWS Secrets Manager or HashiCorp Vault.
+
+#### Reporting
+
+Periodic reports are separate from operational notifications. Configure via the `reporting` block:
+
+```hcl
+reporting = {
+  email_reports      = true   # Send periodic coverage/savings reports via email
+  format             = "html" # html, json, or csv
+  include_debug_data = false  # Include raw API responses (for troubleshooting)
+}
+```
+
+**Note:** The `notifications.emails` list is used for both operational alerts (scheduler/purchaser) and periodic reports (if `reporting.email_reports = true`). To receive reports, you must:
+1. Configure `notifications.emails` with recipient addresses
+2. Set `reporting.email_reports = true`
 
 ### Data Granularity
 

--- a/variables.tf
+++ b/variables.tf
@@ -262,7 +262,7 @@ variable "reporting" {
   type = object({
     enabled            = optional(bool, true)
     format             = optional(string, "html")
-    email_reports      = optional(bool, false)
+    email_reports      = optional(bool, true)
     retention_days     = optional(number, 365)
     include_debug_data = optional(bool, false)
 


### PR DESCRIPTION
## Summary
Changes the `reporting.email_reports` default from `false` to `true` and improves documentation.

## Context
Currently, users configure `notifications.emails` but don't receive reports unless they explicitly set `reporting.email_reports = true`. This creates confusion since:
- The reporter Lambda runs and generates reports
- Reports are stored in S3
- But emails aren't sent by default

## Changes
1. **variables.tf**: Change `email_reports` default from `false` to `true`
2. **README.md**: Add "Reporting" subsection explaining periodic reports vs operational notifications
3. **README.md**: Update Quick Start to show reporting as optional (now true by default)

## Breaking Change
⚠️ This is a **breaking change** for users who:
- Currently rely on `email_reports = false` default
- Want reports generated but NOT emailed

These users will need to explicitly set `reporting.email_reports = false`.

## Reasoning for Change
**Pros:**
- More intuitive UX - configuring emails should send emails
- Reporter Lambda's primary purpose is sending reports
- Aligns with user expectations

**Cons:**
- Breaking change for existing users (though likely very few)
- Users who only want S3 storage must opt-out

## Alternative
Keep the default as `false` and improve documentation to make it clearer that users must opt-in to receive emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)