### PR TITLE
fix: eliminate AWS API costs from integration tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -504,6 +504,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+      - name: Pre-Test Cleanup
+        working-directory: terraform-tests/integration
+        run: |
+          echo "Cleaning up any orphaned resources before tests..."
+          go mod download
+          go test -v -timeout 10m -run TestCleanupAllOrphanedResources || true
+
       - name: Install Terratest Dependencies
         working-directory: terraform-tests/integration
         run: |
@@ -590,7 +597,8 @@ jobs:
         working-directory: terraform-tests/integration
         run: |
           echo "Running cleanup of all orphaned test resources..."
-          go test -v -timeout 15m -run TestCleanupAllOrphanedResources || true
+          go test -v -timeout 15m -run TestCleanupAllOrphanedResources
+        continue-on-error: true
 
       - name: Cleanup Summary
         if: always()


### PR DESCRIPTION
## Problem

Integration tests were invoking Lambda functions which made real AWS Cost Explorer API calls, resulting in:
- ~314 Cost Explorer API calls per month → AWS charges 💸
- Automatic CloudWatch Log Group creation → orphaned resources
- Testing application logic (already covered by Python unit tests)

## Solution

### 1. Removed Phase 3 (Functional Testing)
- Terraform integration tests now only validate infrastructure creation
- No Lambda invocations = no AWS API calls = no costs
- Application logic tested separately in Python unit tests with mocks

### 2. Added Pre-Test Cleanup
- Runs `TestCleanupAllOrphanedResources` before tests start
- Ensures clean slate for each test run
- Prevents resource conflicts from previous failed runs

### 3. Improved Post-Test Cleanup Visibility
- Changed from `|| true` (silent failure) to `continue-on-error: true`
- Cleanup failures now visible in GitHub Actions logs
- Better observability for troubleshooting

## Impact

**Cost Savings:**
- Before: ~314 Cost Explorer API calls/month
- After: 0 calls ✅

**Resource Cleanup:**
- No orphaned CloudWatch Log Groups from Lambda invocations
- Pre-test cleanup removes residual resources
- Better cleanup error visibility

**Test Scope:**
- Terraform tests: Infrastructure validation only ✅
- Python tests: Application logic with mocks ✅
- No duplication between test layers

## Testing

The cleanup script (`TestCleanupAllOrphanedResources`) handles all orphaned resources via AWS APIs:
- CloudWatch Log Groups & Alarms
- Lambda Functions
- EventBridge Rules
- SQS Queues
- SNS Topics & Subscriptions
- IAM Roles
- S3 Buckets (empties contents first)

All resources matching `sp-autopilot-test-*` pattern are cleaned up automatically.