### PR TITLE
feat: add fail-fast to integration tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -521,7 +521,7 @@ jobs:
       - name: Run Terratest Integration Tests
         working-directory: terraform-tests/integration
         run: |
-          go test -v -timeout 30m -parallel 1
+          go test -v -timeout 30m -parallel 1 -failfast -skip TestCleanupAllOrphanedResources
         env:
           TF_VAR_environment: ci-test
           TF_VAR_project_name: sp-autopilot-ci


### PR DESCRIPTION
## Summary
- Adds `-failfast` flag to integration tests to stop execution immediately after first failure
- Adds `-skip TestCleanupAllOrphanedResources` to avoid redundant test execution

## Problem
Integration tests currently run for 15+ minutes even when a test fails at minute 3, wasting time and GitHub Actions minutes.

## Solution
The `-failfast` flag tells Go's test runner to stop immediately after the first test failure, preventing unnecessary execution of subsequent tests.

The cleanup test is skipped since it already runs separately in the pre-test and post-test cleanup steps.

## Test plan
- [x] Integration tests will stop on first failure
- [x] Cleanup test runs separately before and after main tests
- [x] No impact on successful test runs


🤖 Generated with [Claude Code](https://claude.com/claude-code)