### PR TITLE
fix: resolve remaining 8 SonarCloud issues

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1090,10 +1090,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .tooltip-value-savings {
-    color: #047857;
+    color: #064e3b;
     font-weight: 700;
     font-size: 1.15em;
-    background: rgba(16, 185, 129, 0.15);
+    background: rgba(16, 185, 129, 0.1);
     padding: 2px 6px;
     border-radius: 3px;
 }

--- a/docs/js/chartManager.js
+++ b/docs/js/chartManager.js
@@ -725,7 +725,7 @@ const ChartManager = (function() {
 
         const dataset1 = curveData.slice(0, minCostIndex + 1).map(toXY);
 
-        const dataset2 = curveData.slice(minCostIndex, Math.min(optimalIndex + 1, (minHourlyReturnIndex !== -1 ? minHourlyReturnIndex : curveData.length - 1) + 1)).map(toXY);
+        const dataset2 = curveData.slice(minCostIndex, Math.min(optimalIndex + 1, (minHourlyReturnIndex === -1 ? curveData.length - 1 : minHourlyReturnIndex) + 1)).map(toXY);
 
         const dataset2Extended = minHourlyReturnIndex === -1 && optimalIndex < curveData.length - 1
             ? curveData.slice(minCostIndex, curveData.length).map(toXY)
@@ -774,11 +774,8 @@ const ChartManager = (function() {
         };
     }
 
-    /**
-     * Update savings curve chart with new data
-     * @param {Object} opts - Chart update options
-     */
-    function updateSavingsCurveChart(curveData, minHourlySavings, optimalCoverage, minCost, maxCost, baselineCost, currentCoverage, savingsPercentage, numHours) {
+    function updateSavingsCurveChart(opts) {
+        const { curveData, minHourlySavings, optimalCoverage, minCost, maxCost, baselineCost, currentCoverage, savingsPercentage, numHours } = opts;
         if (!savingsCurveChart) return;
 
         savingsCurveChart.$minHourlySavings = minHourlySavings;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1086,17 +1086,17 @@
         const currentCoverageFromData = appState.coverageCost;
 
         // Update chart (use optimal from curve data for consistency)
-        ChartManager.updateSavingsCurveChart(
+        ChartManager.updateSavingsCurveChart({
             curveData,
             minHourlySavings,
             optimalCoverage,
             minCost,
-            chartMaxCost,
+            maxCost: chartMaxCost,
             baselineCost,
-            currentCoverageFromData,
+            currentCoverage: currentCoverageFromData,
             savingsPercentage,
-            hourlyCosts.length
-        );
+            numHours: hourlyCosts.length
+        });
     }
 
     /**

--- a/docs/js/spCalculations.js
+++ b/docs/js/spCalculations.js
@@ -145,7 +145,7 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 
 // Also make available globally for browser usage
-if (typeof globalThis.window !== 'undefined') {
+if (globalThis.window !== undefined) {
     globalThis.SPCalculations = {
         coverageFromCommitment,
         commitmentFromCoverage,

--- a/docs/tests/fixtures/reporter-sample.html
+++ b/docs/tests/fixtures/reporter-sample.html
@@ -15,10 +15,10 @@
         .container { background-color: white; padding: 30px; border-radius: 8px; }
         h1 { color: #232f3e; border-bottom: 3px solid #ff9900; padding-bottom: 10px; }
         .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; margin-bottom: 20px; }
-        .summary-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 15px; border-radius: 6px; }
+        .summary-card { background: linear-gradient(135deg, #4f5ebf 0%, #764ba2 100%); color: white; padding: 15px; border-radius: 6px; }
         .summary-card h3 { margin: 0 0 6px 0; font-size: 0.8em; }
         .summary-card .value { font-size: 1.6em; font-weight: bold; margin: 0; }
-        .simulator-button { display: inline-block; background: #ff9900; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px; margin: 20px 0; }
+        .simulator-button { display: inline-block; background: #ff9900; color: #232f3e; padding: 10px 20px; text-decoration: none; border-radius: 4px; margin: 20px 0; font-weight: 600; }
         .tab-button { padding: 10px 20px; margin: 5px; border: none; background: #e0e0e0; cursor: pointer; border-radius: 4px; }
         .tab-button.active { background: #232f3e; color: white; }
         .metric-card { background: white; padding: 15px; border: 1px solid #e0e0e0; border-radius: 6px; margin: 10px 0; }
@@ -87,7 +87,7 @@
         if (typeof Chart !== 'undefined') {
             const ctx = document.getElementById('coverageChart');
             if (ctx) {
-                const _chart = new Chart(ctx, {
+                new Chart(ctx, {
                     type: 'line',
                     data: {
                         labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],

--- a/docs/tests/helpers/assertions.js
+++ b/docs/tests/helpers/assertions.js
@@ -92,7 +92,7 @@ export function parseDollarAmount(formattedValue) {
  * @returns {number} Numeric value
  */
 export function parsePercentage(formattedValue) {
-  return Number.parseFloat(formattedValue.replaceAll(/%/g, ''));
+  return Number.parseFloat(formattedValue.replaceAll('%', ''));
 }
 
 /**


### PR DESCRIPTION
## Summary
- **S107**: Bundle `updateSavingsCurveChart` 9 params into single options object (chartManager.js + main.js call site)
- **S7735**: Flip negated ternary `!== -1 ? a : b` → `=== -1 ? b : a` (chartManager.js)
- **S7741**: `typeof globalThis.window !== 'undefined'` → `globalThis.window !== undefined` (spCalculations.js)
- **S7781**: `.replaceAll(/%/g, '')` → `.replaceAll('%', '')` — string arg instead of regex (assertions.js)
- **S1481**: Remove unused `_chart` variable, call `new Chart()` directly for side effect (reporter-sample.html)
- **S7924** (x3): Fix CSS contrast — darken savings tooltip text to `#064e3b`, darken gradient start to `#4f5ebf`, use dark text `#232f3e` on orange button (styles.css, reporter-sample.html)

## Test plan
- [ ] Verify SonarCloud shows 0 new issues
- [ ] Verify savings curve chart renders correctly after params refactor
- [ ] Verify Playwright tests still pass