### PR TITLE
Add GA4 tracking to GH Pages simulator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Interactive AWS Savings Plan cost optimization simulator. Visualize savings across different load patterns.">
     <title>AWS Savings Plan Simulator | Interactive Cost Optimizer</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ED5L4MR99H"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-ED5L4MR99H');
+    </script>
     <link rel="stylesheet" href="css/styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.0.1/dist/chartjs-plugin-annotation.min.js"></script>


### PR DESCRIPTION
## Summary
- Add Google Analytics 4 tracking snippet to the simulator page
- Measurement ID: G-ED5L4MR99H
- Tracks page views, scrolls, and outbound clicks