### PR TITLE
ci: serialize integration tests to prevent concurrent AWS conflicts

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -471,6 +471,9 @@ jobs:
     name: Terraform Integration Tests
     runs-on: ubuntu-latest
     needs: [terraform-validation, tfsec-scan, lint, terraform-unit-tests]
+    concurrency:
+      group: aws-integration-tests
+      cancel-in-progress: false
     timeout-minutes: 30
     permissions:
       contents: read
@@ -559,6 +562,9 @@ jobs:
     name: Cleanup AWS Resources
     runs-on: ubuntu-latest
     needs: terraform-integration-tests
+    concurrency:
+      group: aws-integration-tests
+      cancel-in-progress: false
     if: always()
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary
- Add job-level concurrency group (`aws-integration-tests`) to both `terraform-integration-tests` and `cleanup-aws-resources` jobs
- Prevents concurrent integration test runs from interfering with each other

## Problem
The pre-test cleanup deletes **all** resources matching `sp-autopilot-test-*`, which destroys resources belonging to other concurrent CI runs mid-apply. This causes IAM roles, SQS queues, and S3 buckets to disappear during terraform apply, producing errors like:
- `NoSuchEntity: The role with name ... cannot be found`
- `The role defined for the function cannot be assumed by Lambda`
- `The specified queue does not exist`

## Test plan
- [ ] Verify integration tests pass when only one run executes at a time
- [ ] Confirm queued runs proceed after the active run completes