### PR TITLE
refactor: reduce SonarCloud code duplication

### DIFF
--- a/docs/js/colorThemes.js
+++ b/docs/js/colorThemes.js
@@ -6,190 +6,73 @@
 const ColorThemes = (function() {
     'use strict';
 
+    function buildTheme(name, colors) {
+        return {
+            name,
+            covered:    { border: colors.covered[0],    background: colors.covered[1] },
+            spillover:  { border: colors.spillover[0],   background: colors.spillover[1] },
+            baseline:   { border: colors.baseline[0],    background: colors.baseline[1] },
+            commitment: { border: colors.commitment[0],  background: colors.commitment[1] },
+            loadPattern:{ border: colors.loadPattern[0], background: colors.loadPattern[1] },
+            savingsCurve: {
+                building:    { border: colors.building[0],    background: colors.building[1] },
+                gaining:     { border: colors.gaining[0],     background: colors.gaining[1] },
+                wasting:     { border: colors.wasting[0],     background: colors.wasting[1] },
+                veryBad:     { border: colors.veryBad[0],     background: colors.veryBad[1] },
+                losingMoney: { border: colors.losingMoney[0], background: colors.losingMoney[1] }
+            }
+        };
+    }
+
     const themes = {
-        default: {
-            name: 'Default',
-            covered: {
-                border: '#00ff88',
-                background: 'rgba(0, 255, 136, 0.3)'
-            },
-            spillover: {
-                border: '#ffaa00',
-                background: 'rgba(255, 170, 0, 0.5)'
-            },
-            baseline: {
-                border: '#8b95a8',
-                background: 'transparent'
-            },
-            commitment: {
-                border: '#00ff88',
-                background: 'transparent'
-            },
-            loadPattern: {
-                border: '#00d4ff',
-                background: 'rgba(0, 212, 255, 0.2)'
-            },
-            savingsCurve: {
-                building: {
-                    border: 'rgba(77, 159, 255, 1)',
-                    background: 'rgba(77, 159, 255, 0.4)'
-                },
-                gaining: {
-                    border: 'rgba(0, 255, 136, 1)',
-                    background: 'rgba(0, 255, 136, 0.4)'
-                },
-                wasting: {
-                    border: 'rgba(255, 170, 0, 1)',
-                    background: 'rgba(255, 170, 0, 0.4)'
-                },
-                veryBad: {
-                    border: 'rgba(138, 43, 226, 1)',
-                    background: 'rgba(138, 43, 226, 0.4)'
-                },
-                losingMoney: {
-                    border: 'rgba(255, 68, 68, 1)',
-                    background: 'rgba(255, 68, 68, 0.4)'
-                }
-            }
-        },
-        protanopia: {
-            name: 'Protanopia (Red-blind)',
-            // Use blue and yellow instead of red and green
-            covered: {
-                border: '#0099ff',  // Blue
-                background: 'rgba(0, 153, 255, 0.3)'
-            },
-            spillover: {
-                border: '#ffcc00',  // Yellow
-                background: 'rgba(255, 204, 0, 0.5)'
-            },
-            baseline: {
-                border: '#8b95a8',
-                background: 'transparent'
-            },
-            commitment: {
-                border: '#0099ff',
-                background: 'transparent'
-            },
-            loadPattern: {
-                border: '#0099ff',
-                background: 'rgba(0, 153, 255, 0.2)'
-            },
-            savingsCurve: {
-                building: {
-                    border: 'rgba(153, 204, 255, 1)',  // Very light blue
-                    background: 'rgba(153, 204, 255, 0.4)'
-                },
-                gaining: {
-                    border: 'rgba(0, 102, 204, 1)',  // Dark blue (high contrast with light blue)
-                    background: 'rgba(0, 102, 204, 0.4)'
-                },
-                wasting: {
-                    border: 'rgba(255, 204, 0, 1)',  // Yellow
-                    background: 'rgba(255, 204, 0, 0.4)'
-                },
-                veryBad: {
-                    border: 'rgba(255, 153, 51, 1)',  // Orange
-                    background: 'rgba(255, 153, 51, 0.4)'
-                },
-                losingMoney: {
-                    border: 'rgba(204, 102, 0, 1)',  // Dark orange
-                    background: 'rgba(204, 102, 0, 0.4)'
-                }
-            }
-        },
-        tritanopia: {
-            name: 'Tritanopia (Blue-blind)',
-            // Use red and green (avoid blue)
-            covered: {
-                border: '#00ff66',  // Bright green
-                background: 'rgba(0, 255, 102, 0.3)'
-            },
-            spillover: {
-                border: '#ff0066',  // Pink/red
-                background: 'rgba(255, 0, 102, 0.5)'
-            },
-            baseline: {
-                border: '#999999',
-                background: 'transparent'
-            },
-            commitment: {
-                border: '#00ff66',
-                background: 'transparent'
-            },
-            loadPattern: {
-                border: '#ff0066',
-                background: 'rgba(255, 0, 102, 0.2)'
-            },
-            savingsCurve: {
-                building: {
-                    border: 'rgba(204, 255, 102, 1)',  // Yellow-green (very distinct from bright green)
-                    background: 'rgba(204, 255, 102, 0.4)'
-                },
-                gaining: {
-                    border: 'rgba(0, 204, 68, 1)',  // Deep/dark green (high contrast)
-                    background: 'rgba(0, 204, 68, 0.4)'
-                },
-                wasting: {
-                    border: 'rgba(255, 204, 0, 1)',  // Pure yellow
-                    background: 'rgba(255, 204, 0, 0.4)'
-                },
-                veryBad: {
-                    border: 'rgba(255, 128, 0, 1)',  // Orange
-                    background: 'rgba(255, 128, 0, 0.4)'
-                },
-                losingMoney: {
-                    border: 'rgba(204, 0, 68, 1)',  // Deep red/magenta
-                    background: 'rgba(204, 0, 68, 0.4)'
-                }
-            }
-        },
-        'high-contrast': {
-            name: 'High Contrast',
-            // Maximum contrast for low vision
-            covered: {
-                border: '#00ff00',  // Pure green
-                background: 'rgba(0, 255, 0, 0.4)'
-            },
-            spillover: {
-                border: '#ffff00',  // Pure yellow
-                background: 'rgba(255, 255, 0, 0.6)'
-            },
-            baseline: {
-                border: '#ffffff',  // White
-                background: 'transparent'
-            },
-            commitment: {
-                border: '#00ff00',
-                background: 'transparent'
-            },
-            loadPattern: {
-                border: '#00ffff',  // Cyan
-                background: 'rgba(0, 255, 255, 0.3)'
-            },
-            savingsCurve: {
-                building: {
-                    border: 'rgba(0, 255, 255, 1)',  // Cyan
-                    background: 'rgba(0, 255, 255, 0.5)'
-                },
-                gaining: {
-                    border: 'rgba(0, 255, 0, 1)',  // Pure green
-                    background: 'rgba(0, 255, 0, 0.5)'
-                },
-                wasting: {
-                    border: 'rgba(255, 255, 0, 1)',  // Pure yellow
-                    background: 'rgba(255, 255, 0, 0.5)'
-                },
-                veryBad: {
-                    border: 'rgba(255, 128, 0, 1)',  // Orange
-                    background: 'rgba(255, 128, 0, 0.5)'
-                },
-                losingMoney: {
-                    border: 'rgba(255, 0, 0, 1)',  // Pure red
-                    background: 'rgba(255, 0, 0, 0.5)'
-                }
-            }
-        }
+        default: buildTheme('Default', {
+            covered:     ['#00ff88', 'rgba(0, 255, 136, 0.3)'],
+            spillover:   ['#ffaa00', 'rgba(255, 170, 0, 0.5)'],
+            baseline:    ['#8b95a8', 'transparent'],
+            commitment:  ['#00ff88', 'transparent'],
+            loadPattern: ['#00d4ff', 'rgba(0, 212, 255, 0.2)'],
+            building:    ['rgba(77, 159, 255, 1)',  'rgba(77, 159, 255, 0.4)'],
+            gaining:     ['rgba(0, 255, 136, 1)',   'rgba(0, 255, 136, 0.4)'],
+            wasting:     ['rgba(255, 170, 0, 1)',   'rgba(255, 170, 0, 0.4)'],
+            veryBad:     ['rgba(138, 43, 226, 1)',  'rgba(138, 43, 226, 0.4)'],
+            losingMoney: ['rgba(255, 68, 68, 1)',   'rgba(255, 68, 68, 0.4)']
+        }),
+        protanopia: buildTheme('Protanopia (Red-blind)', {
+            covered:     ['#0099ff', 'rgba(0, 153, 255, 0.3)'],
+            spillover:   ['#ffcc00', 'rgba(255, 204, 0, 0.5)'],
+            baseline:    ['#8b95a8', 'transparent'],
+            commitment:  ['#0099ff', 'transparent'],
+            loadPattern: ['#0099ff', 'rgba(0, 153, 255, 0.2)'],
+            building:    ['rgba(153, 204, 255, 1)', 'rgba(153, 204, 255, 0.4)'],
+            gaining:     ['rgba(0, 102, 204, 1)',   'rgba(0, 102, 204, 0.4)'],
+            wasting:     ['rgba(255, 204, 0, 1)',   'rgba(255, 204, 0, 0.4)'],
+            veryBad:     ['rgba(255, 153, 51, 1)',  'rgba(255, 153, 51, 0.4)'],
+            losingMoney: ['rgba(204, 102, 0, 1)',   'rgba(204, 102, 0, 0.4)']
+        }),
+        tritanopia: buildTheme('Tritanopia (Blue-blind)', {
+            covered:     ['#00ff66', 'rgba(0, 255, 102, 0.3)'],
+            spillover:   ['#ff0066', 'rgba(255, 0, 102, 0.5)'],
+            baseline:    ['#999999', 'transparent'],
+            commitment:  ['#00ff66', 'transparent'],
+            loadPattern: ['#ff0066', 'rgba(255, 0, 102, 0.2)'],
+            building:    ['rgba(204, 255, 102, 1)', 'rgba(204, 255, 102, 0.4)'],
+            gaining:     ['rgba(0, 204, 68, 1)',    'rgba(0, 204, 68, 0.4)'],
+            wasting:     ['rgba(255, 204, 0, 1)',   'rgba(255, 204, 0, 0.4)'],
+            veryBad:     ['rgba(255, 128, 0, 1)',   'rgba(255, 128, 0, 0.4)'],
+            losingMoney: ['rgba(204, 0, 68, 1)',    'rgba(204, 0, 68, 0.4)']
+        }),
+        'high-contrast': buildTheme('High Contrast', {
+            covered:     ['#00ff00', 'rgba(0, 255, 0, 0.4)'],
+            spillover:   ['#ffff00', 'rgba(255, 255, 0, 0.6)'],
+            baseline:    ['#ffffff', 'transparent'],
+            commitment:  ['#00ff00', 'transparent'],
+            loadPattern: ['#00ffff', 'rgba(0, 255, 255, 0.3)'],
+            building:    ['rgba(0, 255, 255, 1)',   'rgba(0, 255, 255, 0.5)'],
+            gaining:     ['rgba(0, 255, 0, 1)',     'rgba(0, 255, 0, 0.5)'],
+            wasting:     ['rgba(255, 255, 0, 1)',   'rgba(255, 255, 0, 0.5)'],
+            veryBad:     ['rgba(255, 128, 0, 1)',   'rgba(255, 128, 0, 0.5)'],
+            losingMoney: ['rgba(255, 0, 0, 1)',     'rgba(255, 0, 0, 0.5)']
+        })
     };
 
     let currentTheme = 'default';

--- a/lambda/reporter/config.py
+++ b/lambda/reporter/config.py
@@ -8,6 +8,12 @@ Autopilot Reporter Lambda function.
 
 from typing import Any
 
+from shared.config_schemas import (
+    AWS_COMMON,
+    SP_TERM_PAYMENT_OPTIONS,
+    SP_TYPE_TOGGLES,
+    STRATEGY_PARAMS,
+)
 from shared.handler_utils import load_config_from_env
 
 
@@ -33,24 +39,7 @@ CONFIG_SCHEMA = {
         "default": "false",
         "env_var": "INCLUDE_DEBUG_DATA",
     },
-    "enable_compute_sp": {
-        "required": False,
-        "type": "bool",
-        "default": "true",
-        "env_var": "ENABLE_COMPUTE_SP",
-    },
-    "enable_database_sp": {
-        "required": False,
-        "type": "bool",
-        "default": "false",
-        "env_var": "ENABLE_DATABASE_SP",
-    },
-    "enable_sagemaker_sp": {
-        "required": False,
-        "type": "bool",
-        "default": "false",
-        "env_var": "ENABLE_SAGEMAKER_SP",
-    },
+    **SP_TYPE_TOGGLES,
     "lookback_days": {
         "required": True,
         "type": "int",
@@ -61,12 +50,7 @@ CONFIG_SCHEMA = {
         "type": "str",
         "env_var": "GRANULARITY",
     },
-    "management_account_role_arn": {
-        "required": False,
-        "type": "str",
-        "env_var": "MANAGEMENT_ACCOUNT_ROLE_ARN",
-    },
-    "tags": {"required": False, "type": "json", "default": "{}", "env_var": "TAGS"},
+    **AWS_COMMON,
     "slack_webhook_url": {
         "required": False,
         "type": "str",
@@ -88,77 +72,8 @@ CONFIG_SCHEMA = {
         "default": "90.0",
         "env_var": "COVERAGE_TARGET_PERCENT",
     },
-    # Scheduler strategy parameters (for preview simulation)
-    "target_strategy_type": {
-        "required": False,
-        "type": "str",
-        "default": "fixed",
-        "env_var": "TARGET_STRATEGY_TYPE",
-    },
-    "split_strategy_type": {
-        "required": False,
-        "type": "str",
-        "default": "linear",
-        "env_var": "SPLIT_STRATEGY_TYPE",
-    },
-    "dynamic_risk_level": {
-        "required": False,
-        "type": "str",
-        "env_var": "DYNAMIC_RISK_LEVEL",
-    },
-    "savings_percentage": {
-        "required": False,
-        "type": "float",
-        "default": "30.0",
-        "env_var": "SAVINGS_PERCENTAGE",
-    },
-    "max_purchase_percent": {
-        "required": False,
-        "type": "float",
-        "default": "10.0",
-        "env_var": "MAX_PURCHASE_PERCENT",
-    },
-    "min_purchase_percent": {
-        "required": False,
-        "type": "float",
-        "default": "1.0",
-        "env_var": "MIN_PURCHASE_PERCENT",
-    },
-    "linear_step_percent": {
-        "required": False,
-        "type": "float",
-        "env_var": "LINEAR_STEP_PERCENT",
-    },
-    "compute_sp_term": {
-        "required": False,
-        "type": "str",
-        "default": "THREE_YEAR",
-        "env_var": "COMPUTE_SP_TERM",
-    },
-    "compute_sp_payment_option": {
-        "required": False,
-        "type": "str",
-        "default": "ALL_UPFRONT",
-        "env_var": "COMPUTE_SP_PAYMENT_OPTION",
-    },
-    "database_sp_payment_option": {
-        "required": False,
-        "type": "str",
-        "default": "NO_UPFRONT",
-        "env_var": "DATABASE_SP_PAYMENT_OPTION",
-    },
-    "sagemaker_sp_term": {
-        "required": False,
-        "type": "str",
-        "default": "THREE_YEAR",
-        "env_var": "SAGEMAKER_SP_TERM",
-    },
-    "sagemaker_sp_payment_option": {
-        "required": False,
-        "type": "str",
-        "default": "ALL_UPFRONT",
-        "env_var": "SAGEMAKER_SP_PAYMENT_OPTION",
-    },
+    **STRATEGY_PARAMS,
+    **SP_TERM_PAYMENT_OPTIONS,
 }
 
 

--- a/lambda/scheduler/config.py
+++ b/lambda/scheduler/config.py
@@ -8,6 +8,12 @@ Autopilot Scheduler Lambda function.
 
 from typing import Any
 
+from shared.config_schemas import (
+    AWS_COMMON,
+    SP_TERM_PAYMENT_OPTIONS,
+    SP_TYPE_TOGGLES,
+    STRATEGY_PARAMS,
+)
 from shared.handler_utils import load_config_from_env
 
 
@@ -21,70 +27,14 @@ CONFIG_SCHEMA = {
         "default": "true",
         "env_var": "DRY_RUN",
     },
-    "enable_compute_sp": {
-        "required": False,
-        "type": "bool",
-        "default": "true",
-        "env_var": "ENABLE_COMPUTE_SP",
-    },
-    "enable_database_sp": {
-        "required": False,
-        "type": "bool",
-        "default": "false",
-        "env_var": "ENABLE_DATABASE_SP",
-    },
-    "enable_sagemaker_sp": {
-        "required": False,
-        "type": "bool",
-        "default": "false",
-        "env_var": "ENABLE_SAGEMAKER_SP",
-    },
+    **SP_TYPE_TOGGLES,
     "coverage_target_percent": {
         "required": False,
         "type": "float",
         "default": "90",
         "env_var": "COVERAGE_TARGET_PERCENT",
     },
-    "target_strategy_type": {
-        "required": False,
-        "type": "str",
-        "default": "fixed",
-        "env_var": "TARGET_STRATEGY_TYPE",
-    },
-    "split_strategy_type": {
-        "required": False,
-        "type": "str",
-        "default": "linear",
-        "env_var": "SPLIT_STRATEGY_TYPE",
-    },
-    "dynamic_risk_level": {
-        "required": False,
-        "type": "str",
-        "env_var": "DYNAMIC_RISK_LEVEL",
-    },
-    "savings_percentage": {
-        "required": False,
-        "type": "float",
-        "default": "30.0",
-        "env_var": "SAVINGS_PERCENTAGE",
-    },
-    "max_purchase_percent": {
-        "required": False,
-        "type": "float",
-        "default": "10",
-        "env_var": "MAX_PURCHASE_PERCENT",
-    },
-    "min_purchase_percent": {
-        "required": False,
-        "type": "float",
-        "default": "1",
-        "env_var": "MIN_PURCHASE_PERCENT",
-    },
-    "linear_step_percent": {
-        "required": False,
-        "type": "float",
-        "env_var": "LINEAR_STEP_PERCENT",
-    },
+    **STRATEGY_PARAMS,
     "renewal_window_days": {
         "required": False,
         "type": "int",
@@ -109,42 +59,8 @@ CONFIG_SCHEMA = {
         "default": "0.001",
         "env_var": "MIN_COMMITMENT_PER_PLAN",
     },
-    "compute_sp_term": {
-        "required": False,
-        "type": "str",
-        "default": "THREE_YEAR",
-        "env_var": "COMPUTE_SP_TERM",
-    },
-    "compute_sp_payment_option": {
-        "required": False,
-        "type": "str",
-        "default": "ALL_UPFRONT",
-        "env_var": "COMPUTE_SP_PAYMENT_OPTION",
-    },
-    "database_sp_payment_option": {
-        "required": False,
-        "type": "str",
-        "default": "NO_UPFRONT",
-        "env_var": "DATABASE_SP_PAYMENT_OPTION",
-    },
-    "sagemaker_sp_term": {
-        "required": False,
-        "type": "str",
-        "default": "THREE_YEAR",
-        "env_var": "SAGEMAKER_SP_TERM",
-    },
-    "sagemaker_sp_payment_option": {
-        "required": False,
-        "type": "str",
-        "default": "ALL_UPFRONT",
-        "env_var": "SAGEMAKER_SP_PAYMENT_OPTION",
-    },
-    "management_account_role_arn": {
-        "required": False,
-        "type": "str",
-        "env_var": "MANAGEMENT_ACCOUNT_ROLE_ARN",
-    },
-    "tags": {"required": False, "type": "json", "default": "{}", "env_var": "TAGS"},
+    **SP_TERM_PAYMENT_OPTIONS,
+    **AWS_COMMON,
 }
 
 

--- a/lambda/scheduler/email_notifications.py
+++ b/lambda/scheduler/email_notifications.py
@@ -24,56 +24,22 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def send_scheduled_email(
-    sns_client: SNSClient,
-    config: dict[str, Any],
-    purchase_plans: list[dict[str, Any]],
-    coverage: dict[str, float] | None,
-    unknown_services: list[str] | None = None,
-) -> None:
-    """
-    Send email notification for scheduled purchases.
-
-    Args:
-        sns_client: Boto3 SNS client
-        config: Configuration dictionary
-        purchase_plans: List of planned purchases
-        coverage: Current coverage (None for follow_aws strategy)
-        unknown_services: List of unknown services found (optional)
-    """
-    logger.info("Sending scheduled purchases email")
-
-    # Format email body
-    email_lines = [
-        "Savings Plans Scheduled for Purchase",
-        "=" * 50,
+def _format_coverage_block(coverage: dict[str, float] | None, config: dict[str, Any]) -> list[str]:
+    if coverage is None:
+        return []
+    return [
+        "Current Coverage:",
+        f"  Compute SP:  {coverage.get('compute', 0):.2f}%",
+        f"  Database SP: {coverage.get('database', 0):.2f}%",
+        f"  SageMaker SP: {coverage.get('sagemaker', 0):.2f}%",
         "",
-        f"Total Plans Queued: {len(purchase_plans)}",
+        f"Target Coverage: {config.get('coverage_target_percent', 90):.2f}%",
         "",
     ]
 
-    # Add coverage info if available (fixed/dichotomy strategies)
-    if coverage is not None:
-        email_lines.extend(
-            [
-                "Current Coverage:",
-                f"  Compute SP:  {coverage.get('compute', 0):.2f}%",
-                f"  Database SP: {coverage.get('database', 0):.2f}%",
-                f"  SageMaker SP: {coverage.get('sagemaker', 0):.2f}%",
-                "",
-                f"Target Coverage: {config.get('coverage_target_percent', 90):.2f}%",
-                "",
-            ]
-        )
 
-    email_lines.extend(
-        [
-            "Scheduled Purchase Plans:",
-            "-" * 50,
-        ]
-    )
-
-    # Add details for each purchase plan
+def _format_plans_block(purchase_plans: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
     total_annual_cost = 0.0
 
     for i, plan in enumerate(purchase_plans, 1):
@@ -82,11 +48,10 @@ def send_scheduled_email(
         term = plan.get("term", "unknown")
         payment_option = plan.get("payment_option", "ALL_UPFRONT")
 
-        # Calculate estimated annual cost (hourly * 24 * 365)
         annual_cost = hourly_commitment * 8760
         total_annual_cost += annual_cost
 
-        email_lines.extend(
+        lines.extend(
             [
                 f"{i}. {sp_type.upper()} Savings Plan",
                 f"   Hourly Commitment: ${hourly_commitment:.4f}/hour",
@@ -97,56 +62,126 @@ def send_scheduled_email(
             ]
         )
 
-    email_lines.extend(
+    lines.extend(
         [
             "-" * 50,
             f"Total Estimated Annual Cost: ${total_annual_cost:,.2f}",
             "",
         ]
     )
+    return lines
 
-    # Add warning if unknown services detected
-    if unknown_services:
-        email_lines.extend(
-            [
-                "⚠️  WARNING: UNKNOWN SERVICES DETECTED",
-                "=" * 50,
-                "",
-                f"Found {len(unknown_services)} service(s) with Savings Plans coverage",
-                "that are NOT in our service constants:",
-                "",
-            ]
-        )
-        for svc in sorted(unknown_services):
-            email_lines.append(f"  - {svc}")
-        email_lines.extend(
-            [
-                "",
-                "Your analysis completed but may have INCOMPLETE coverage data.",
-                "This likely means AWS added new services that support Savings Plans.",
-                "",
-                "ACTION REQUIRED:",
-                "1. Open issue: https://github.com/etiennechabert/terraform-aws-sp-autopilot/issues/new",
-                "2. Title: New AWS services support Savings Plans",
-                "3. Copy-paste:",
-                "",
-                f"   AWS added {len(unknown_services)} new service(s):",
-            ]
-        )
-        for svc in sorted(unknown_services):
-            email_lines.append(f"   - {svc}")
-        email_lines.extend(
-            [
-                "",
-                "   Please update lambda/shared/spending_analyzer.py",
-                "",
-                "=" * 50,
-                "",
-            ]
-        )
 
-    email_lines.extend(
+def _format_unknown_services_warning(
+    unknown_services: list[str] | None,
+) -> list[str]:
+    if not unknown_services:
+        return []
+    lines = [
+        "⚠️  WARNING: UNKNOWN SERVICES DETECTED",
+        "=" * 50,
+        "",
+        f"Found {len(unknown_services)} service(s) with Savings Plans coverage",
+        "that are NOT in our service constants:",
+        "",
+    ]
+    for svc in sorted(unknown_services):
+        lines.append(f"  - {svc}")
+    lines.extend(
         [
+            "",
+            "Your analysis completed but may have INCOMPLETE coverage data.",
+            "This likely means AWS added new services that support Savings Plans.",
+            "",
+            "ACTION REQUIRED:",
+            "1. Open issue: https://github.com/etiennechabert/terraform-aws-sp-autopilot/issues/new",
+            "2. Title: New AWS services support Savings Plans",
+            "3. Copy-paste:",
+            "",
+            f"   AWS added {len(unknown_services)} new service(s):",
+        ]
+    )
+    for svc in sorted(unknown_services):
+        lines.append(f"   - {svc}")
+    lines.extend(
+        [
+            "",
+            "   Please update lambda/shared/spending_analyzer.py",
+            "",
+            "=" * 50,
+            "",
+        ]
+    )
+    return lines
+
+
+def _format_and_send(
+    sns_client: SNSClient,
+    config: dict[str, Any],
+    purchase_plans: list[dict[str, Any]],
+    coverage: dict[str, float] | None,
+    unknown_services: list[str] | None,
+    *,
+    header_lines: list[str],
+    plans_heading: str,
+    footer_lines: list[str],
+    subject: str,
+    log_label: str,
+) -> None:
+    email_lines = [
+        *header_lines,
+        *_format_coverage_block(coverage, config),
+        plans_heading,
+        "-" * 50,
+        *_format_plans_block(purchase_plans),
+        *_format_unknown_services_warning(unknown_services),
+        *footer_lines,
+    ]
+
+    message = "\n".join(email_lines)
+
+    if local_mode.is_local_mode():
+        logger.info(f"LOCAL MODE: Skipping SNS publish. {log_label} email content:")
+        logger.info("=" * 60)
+        logger.info(message)
+        logger.info("=" * 60)
+        return
+
+    try:
+        sns_client.publish(
+            TopicArn=config["sns_topic_arn"],
+            Subject=subject,
+            Message=message,
+        )
+        logger.info(f"{log_label} email sent successfully to {config['sns_topic_arn']}")
+    except ClientError as e:
+        logger.error(f"Failed to send {log_label.lower()} email: {e!s}")
+        raise
+
+
+def send_scheduled_email(
+    sns_client: SNSClient,
+    config: dict[str, Any],
+    purchase_plans: list[dict[str, Any]],
+    coverage: dict[str, float] | None,
+    unknown_services: list[str] | None = None,
+) -> None:
+    logger.info("Sending scheduled purchases email")
+    _format_and_send(
+        sns_client,
+        config,
+        purchase_plans,
+        coverage,
+        unknown_services,
+        header_lines=[
+            "Savings Plans Scheduled for Purchase",
+            "=" * 50,
+            "",
+            f"Total Plans Queued: {len(purchase_plans)}",
+            "",
+        ],
+        plans_heading="Scheduled Purchase Plans:",
+        footer_lines=[
             "CANCELLATION INSTRUCTIONS:",
             "To cancel these purchases before they execute:",
             "1. Purge the SQS queue to remove all pending purchase intents",
@@ -156,30 +191,10 @@ def send_scheduled_email(
             "",
             "These purchases will be executed by the Purchaser Lambda.",
             "Monitor CloudWatch Logs and SNS notifications for execution results.",
-        ]
+        ],
+        subject="Savings Plans Scheduled for Purchase",
+        log_label="Scheduled",
     )
-
-    message = "\n".join(email_lines)
-
-    # Skip SNS publishing in local mode
-    if local_mode.is_local_mode():
-        logger.info("LOCAL MODE: Skipping SNS publish. Email content:")
-        logger.info("=" * 60)
-        logger.info(message)
-        logger.info("=" * 60)
-        return
-
-    # Publish to SNS
-    try:
-        sns_client.publish(
-            TopicArn=config["sns_topic_arn"],
-            Subject="Savings Plans Scheduled for Purchase",
-            Message=message,
-        )
-        logger.info(f"Email sent successfully to {config['sns_topic_arn']}")
-    except ClientError as e:
-        logger.error(f"Failed to send email: {e!s}")
-        raise
 
 
 def send_dry_run_email(
@@ -189,124 +204,24 @@ def send_dry_run_email(
     coverage: dict[str, float] | None,
     unknown_services: list[str] | None = None,
 ) -> None:
-    """
-    Send email notification for dry run analysis.
-
-    Args:
-        sns_client: Boto3 SNS client
-        config: Configuration dictionary
-        purchase_plans: List of what would be purchased
-        coverage: Current coverage (None for follow_aws strategy)
-        unknown_services: List of unknown services found (optional)
-    """
     logger.info("Sending dry run email")
-
-    # Format email body
-    email_lines = [
-        "***** DRY RUN MODE ***** Savings Plans Analysis",
-        "=" * 50,
-        "",
-        "*** NO PURCHASES WERE SCHEDULED ***",
-        "",
-        f"Total Plans Analyzed: {len(purchase_plans)}",
-        "",
-    ]
-
-    # Add coverage info if available (fixed/dichotomy strategies)
-    if coverage is not None:
-        email_lines.extend(
-            [
-                "Current Coverage:",
-                f"  Compute SP:  {coverage.get('compute', 0):.2f}%",
-                f"  Database SP: {coverage.get('database', 0):.2f}%",
-                f"  SageMaker SP: {coverage.get('sagemaker', 0):.2f}%",
-                "",
-                f"Target Coverage: {config.get('coverage_target_percent', 90):.2f}%",
-                "",
-            ]
-        )
-
-    email_lines.extend(
-        [
-            "Purchase Plans (WOULD BE SCHEDULED if dry_run=false):",
-            "-" * 50,
-        ]
-    )
-
-    # Add details for each purchase plan
-    total_annual_cost = 0.0
-
-    for i, plan in enumerate(purchase_plans, 1):
-        sp_type = plan.get("sp_type", "unknown")
-        hourly_commitment = plan.get("hourly_commitment", 0.0)
-        term = plan.get("term", "unknown")
-        payment_option = plan.get("payment_option", "ALL_UPFRONT")
-
-        # Calculate estimated annual cost (hourly * 24 * 365)
-        annual_cost = hourly_commitment * 8760
-        total_annual_cost += annual_cost
-
-        email_lines.extend(
-            [
-                f"{i}. {sp_type.upper()} Savings Plan",
-                f"   Hourly Commitment: ${hourly_commitment:.4f}/hour",
-                f"   Term: {term}",
-                f"   Payment Option: {payment_option}",
-                f"   Estimated Annual Cost: ${annual_cost:,.2f}",
-                "",
-            ]
-        )
-
-    email_lines.extend(
-        [
-            "-" * 50,
-            f"Total Estimated Annual Cost: ${total_annual_cost:,.2f}",
+    _format_and_send(
+        sns_client,
+        config,
+        purchase_plans,
+        coverage,
+        unknown_services,
+        header_lines=[
+            "***** DRY RUN MODE ***** Savings Plans Analysis",
+            "=" * 50,
             "",
-        ]
-    )
-
-    # Add warning if unknown services detected
-    if unknown_services:
-        email_lines.extend(
-            [
-                "⚠️  WARNING: UNKNOWN SERVICES DETECTED",
-                "=" * 50,
-                "",
-                f"Found {len(unknown_services)} service(s) with Savings Plans coverage",
-                "that are NOT in our service constants:",
-                "",
-            ]
-        )
-        for svc in sorted(unknown_services):
-            email_lines.append(f"  - {svc}")
-        email_lines.extend(
-            [
-                "",
-                "Your analysis completed but may have INCOMPLETE coverage data.",
-                "This likely means AWS added new services that support Savings Plans.",
-                "",
-                "ACTION REQUIRED:",
-                "1. Open issue: https://github.com/etiennechabert/terraform-aws-sp-autopilot/issues/new",
-                "2. Title: New AWS services support Savings Plans",
-                "3. Copy-paste:",
-                "",
-                f"   AWS added {len(unknown_services)} new service(s):",
-            ]
-        )
-        for svc in sorted(unknown_services):
-            email_lines.append(f"   - {svc}")
-        email_lines.extend(
-            [
-                "",
-                "   Please update lambda/shared/spending_analyzer.py",
-                "",
-                "=" * 50,
-                "",
-            ]
-        )
-
-    email_lines.extend(
-        [
+            "*** NO PURCHASES WERE SCHEDULED ***",
+            "",
+            f"Total Plans Analyzed: {len(purchase_plans)}",
+            "",
+        ],
+        plans_heading="Purchase Plans (WOULD BE SCHEDULED if dry_run=false):",
+        footer_lines=[
             "TO ENABLE ACTUAL PURCHASES:",
             "1. Set the DRY_RUN environment variable to 'false'",
             "2. Update the Lambda configuration:",
@@ -319,27 +234,7 @@ def send_dry_run_email(
             "",
             "Once disabled, the Scheduler will queue purchase intents to SQS,",
             "and the Purchaser Lambda will execute the actual purchases.",
-        ]
+        ],
+        subject="[DRY RUN] Savings Plans Analysis - No Purchases Scheduled",
+        log_label="Dry run",
     )
-
-    message = "\n".join(email_lines)
-
-    # Skip SNS publishing in local mode
-    if local_mode.is_local_mode():
-        logger.info("LOCAL MODE: Skipping SNS publish. Dry run email content:")
-        logger.info("=" * 60)
-        logger.info(message)
-        logger.info("=" * 60)
-        return
-
-    # Publish to SNS
-    try:
-        sns_client.publish(
-            TopicArn=config["sns_topic_arn"],
-            Subject="[DRY RUN] Savings Plans Analysis - No Purchases Scheduled",
-            Message=message,
-        )
-        logger.info(f"Dry run email sent successfully to {config['sns_topic_arn']}")
-    except ClientError as e:
-        logger.error(f"Failed to send dry run email: {e!s}")
-        raise

--- a/lambda/shared/config_schemas.py
+++ b/lambda/shared/config_schemas.py
@@ -1,0 +1,105 @@
+SP_TYPE_TOGGLES = {
+    "enable_compute_sp": {
+        "required": False,
+        "type": "bool",
+        "default": "true",
+        "env_var": "ENABLE_COMPUTE_SP",
+    },
+    "enable_database_sp": {
+        "required": False,
+        "type": "bool",
+        "default": "false",
+        "env_var": "ENABLE_DATABASE_SP",
+    },
+    "enable_sagemaker_sp": {
+        "required": False,
+        "type": "bool",
+        "default": "false",
+        "env_var": "ENABLE_SAGEMAKER_SP",
+    },
+}
+
+STRATEGY_PARAMS = {
+    "target_strategy_type": {
+        "required": False,
+        "type": "str",
+        "default": "fixed",
+        "env_var": "TARGET_STRATEGY_TYPE",
+    },
+    "split_strategy_type": {
+        "required": False,
+        "type": "str",
+        "default": "linear",
+        "env_var": "SPLIT_STRATEGY_TYPE",
+    },
+    "dynamic_risk_level": {
+        "required": False,
+        "type": "str",
+        "env_var": "DYNAMIC_RISK_LEVEL",
+    },
+    "savings_percentage": {
+        "required": False,
+        "type": "float",
+        "default": "30.0",
+        "env_var": "SAVINGS_PERCENTAGE",
+    },
+    "max_purchase_percent": {
+        "required": False,
+        "type": "float",
+        "default": "10.0",
+        "env_var": "MAX_PURCHASE_PERCENT",
+    },
+    "min_purchase_percent": {
+        "required": False,
+        "type": "float",
+        "default": "1.0",
+        "env_var": "MIN_PURCHASE_PERCENT",
+    },
+    "linear_step_percent": {
+        "required": False,
+        "type": "float",
+        "env_var": "LINEAR_STEP_PERCENT",
+    },
+}
+
+SP_TERM_PAYMENT_OPTIONS = {
+    "compute_sp_term": {
+        "required": False,
+        "type": "str",
+        "default": "THREE_YEAR",
+        "env_var": "COMPUTE_SP_TERM",
+    },
+    "compute_sp_payment_option": {
+        "required": False,
+        "type": "str",
+        "default": "ALL_UPFRONT",
+        "env_var": "COMPUTE_SP_PAYMENT_OPTION",
+    },
+    "database_sp_payment_option": {
+        "required": False,
+        "type": "str",
+        "default": "NO_UPFRONT",
+        "env_var": "DATABASE_SP_PAYMENT_OPTION",
+    },
+    "sagemaker_sp_term": {
+        "required": False,
+        "type": "str",
+        "default": "THREE_YEAR",
+        "env_var": "SAGEMAKER_SP_TERM",
+    },
+    "sagemaker_sp_payment_option": {
+        "required": False,
+        "type": "str",
+        "default": "ALL_UPFRONT",
+        "env_var": "SAGEMAKER_SP_PAYMENT_OPTION",
+    },
+}
+
+AWS_COMMON = {
+    "management_account_role_arn": {
+        "required": False,
+        "type": "str",
+        "env_var": "MANAGEMENT_ACCOUNT_ROLE_ARN",
+    },
+    "tags": {"required": False, "type": "json", "default": "{}", "env_var": "TAGS"},
+}


### PR DESCRIPTION
## Summary

- **email_notifications.py**: Extract shared formatting logic (`_format_coverage_block`, `_format_plans_block`, `_format_unknown_services_warning`) and a `_format_and_send` orchestrator — `send_scheduled_email` / `send_dry_run_email` become thin wrappers passing mode-specific header/footer/subject
- **colorThemes.js**: Add `buildTheme(name, colors)` factory that maps flat `[border, background]` pairs into the nested structure, eliminating repeated `{ border: ..., background: ... }` blocks across 4 themes
- **config schemas**: Create `shared/config_schemas.py` with `SP_TYPE_TOGGLES`, `STRATEGY_PARAMS`, `SP_TERM_PAYMENT_OPTIONS`, `AWS_COMMON` — both `scheduler/config.py` and `reporter/config.py` import and spread these instead of duplicating ~30 identical schema entries each

Net: **-286 lines** (325 added, 611 removed), no behavioral changes. All 135 tests pass.