### PR TITLE
feat: reintroduce time-based multipliers and fake coverage in demo mode

### DIFF
--- a/lambda/shared/demo_mode.py
+++ b/lambda/shared/demo_mode.py
@@ -15,6 +15,7 @@ import math
 import os
 import random
 from copy import deepcopy
+from datetime import datetime
 from typing import Any
 
 
@@ -45,8 +46,12 @@ def randomize_report_data(
     factor = _random_factor()
     logger.info("Demo mode active - applying random scaling factor (data is not real)")
 
-    coverage_out = _scale_coverage_data(deepcopy(coverage_data), factor)
-    daily_out = _scale_coverage_data(deepcopy(daily_coverage_data), factor)
+    coverage_out = _scale_coverage_data(deepcopy(coverage_data), factor, is_daily=False)
+    daily_out = _scale_coverage_data(deepcopy(daily_coverage_data), factor, is_daily=True)
+
+    coverage_pcts = _apply_fake_coverage(coverage_out)
+    _apply_fake_coverage(daily_out, coverage_pcts=coverage_pcts)
+
     savings_out = _scale_savings_data(deepcopy(savings_data), factor)
 
     return coverage_out, daily_out, savings_out
@@ -64,7 +69,19 @@ def _scale(value: float, factor: float) -> float:
     return round(value * factor, 6)
 
 
-def _scale_coverage_data(data: dict[str, Any], factor: float) -> dict[str, Any]:
+def _time_multiplier(timestamp_str: str, is_daily: bool) -> float:
+    """Generate a deterministic random multiplier (1.5-2.5) based on time.
+
+    For daily data: varies by day of the week (0=Monday .. 6=Sunday).
+    For hourly data: varies by hour of the day (0-23).
+    """
+    dt = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+    seed = dt.isoweekday() if is_daily else dt.hour
+    rng = random.Random(seed)
+    return rng.uniform(1.5, 2.5)
+
+
+def _scale_coverage_data(data: dict[str, Any], factor: float, *, is_daily: bool) -> dict[str, Any]:
     """Scale dollar amounts in coverage data (hourly or daily)."""
     for sp_type in ("compute", "database", "sagemaker"):
         if sp_type not in data:
@@ -72,11 +89,11 @@ def _scale_coverage_data(data: dict[str, Any], factor: float) -> dict[str, Any]:
 
         type_data = data[sp_type]
 
-        # Scale timeseries
+        # Scale timeseries with time-based multiplier
         for point in type_data.get("timeseries", []):
-            point["covered"] = _scale(point["covered"], factor)
-            point["total"] = _scale(point["total"], factor)
-            # coverage % is recalculated from covered/total, stays consistent
+            tm = _time_multiplier(point["timestamp"], is_daily)
+            point["covered"] = _scale(point["covered"], factor * tm)
+            point["total"] = _scale(point["total"], factor * tm)
 
         # Scale summary dollar amounts (not percentages)
         summary = type_data.get("summary", {})
@@ -92,6 +109,47 @@ def _scale_coverage_data(data: dict[str, Any], factor: float) -> dict[str, Any]:
                 summary[key] = _scale(summary[key], factor)
 
     return data
+
+
+def _apply_fake_coverage(
+    data: dict[str, Any],
+    coverage_pcts: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Set SP coverage as a flat line at a random 25-75% of min-hourly total.
+
+    If coverage_pcts is provided, reuse those percentages (so hourly and daily
+    data share the same coverage ratio per SP type). Returns the percentages used.
+    """
+    generated_pcts: dict[str, float] = {}
+    for sp_type in ("compute", "database", "sagemaker"):
+        if sp_type not in data:
+            continue
+
+        type_data = data[sp_type]
+        timeseries = type_data.get("timeseries", [])
+        totals = [p["total"] for p in timeseries if p["total"] > 0]
+        if not totals:
+            continue
+
+        min_total = min(totals)
+
+        if coverage_pcts and sp_type in coverage_pcts:
+            pct = coverage_pcts[sp_type]
+        else:
+            pct = random.uniform(0.25, 0.75)
+        generated_pcts[sp_type] = pct
+
+        flat_covered = round(min_total * pct, 6)
+        for point in timeseries:
+            point["covered"] = flat_covered
+
+        summary = type_data.get("summary", {})
+        if "avg_hourly_covered" in summary:
+            summary["avg_hourly_covered"] = flat_covered
+        if "est_monthly_covered" in summary:
+            summary["est_monthly_covered"] = round(flat_covered * 720, 6)
+
+    return generated_pcts
 
 
 def _scale_savings_data(data: dict[str, Any], factor: float) -> dict[str, Any]:

--- a/lambda/shared/tests/unit/test_demo_mode.py
+++ b/lambda/shared/tests/unit/test_demo_mode.py
@@ -7,10 +7,12 @@ import pytest
 
 from shared.demo_mode import (
     _anonymize_id,
+    _apply_fake_coverage,
     _random_factor,
     _scale,
     _scale_coverage_data,
     _scale_savings_data,
+    _time_multiplier,
     is_demo_mode,
     randomize_report_data,
 )
@@ -103,20 +105,50 @@ class TestScale:
         assert _scale(0.0, 5.0) == 0.0
 
 
+class TestTimeMultiplier:
+    def test_range(self):
+        for hour in range(24):
+            ts = f"2026-01-15T{hour:02d}:00:00Z"
+            m = _time_multiplier(ts, is_daily=False)
+            assert 1.5 <= m <= 2.5
+
+    def test_daily_varies_by_weekday(self):
+        # Monday and Sunday should produce different multipliers
+        mon = _time_multiplier("2026-01-19T00:00:00Z", is_daily=True)  # Monday
+        sun = _time_multiplier(
+            "2026-01-18T00:00:00Z", is_daily=True
+        )  # Sunday (different isoweekday)
+        assert mon != sun
+
+    def test_hourly_varies_by_hour(self):
+        m0 = _time_multiplier("2026-01-15T00:00:00Z", is_daily=False)
+        m12 = _time_multiplier("2026-01-15T12:00:00Z", is_daily=False)
+        assert m0 != m12
+
+    def test_deterministic(self):
+        a = _time_multiplier("2026-01-15T05:00:00Z", is_daily=False)
+        b = _time_multiplier("2026-01-15T05:00:00Z", is_daily=False)
+        assert a == b
+
+
 class TestScaleCoverageData:
-    def test_scales_timeseries(self):
+    def test_scales_timeseries_with_time_multiplier(self):
         from copy import deepcopy
 
         data = deepcopy(COVERAGE_DATA)
-        result = _scale_coverage_data(data, 3.0)
-        assert result["compute"]["timeseries"][0]["covered"] == pytest.approx(30.0)
-        assert result["compute"]["timeseries"][0]["total"] == pytest.approx(45.0)
+        factor = 3.0
+        result = _scale_coverage_data(data, factor, is_daily=False)
+        # Timeseries values include the time multiplier, so they won't be exactly factor * original
+        ts0 = result["compute"]["timeseries"][0]
+        tm = _time_multiplier("2026-01-01T00:00:00Z", is_daily=False)
+        assert ts0["covered"] == pytest.approx(10.0 * factor * tm, rel=1e-4)
+        assert ts0["total"] == pytest.approx(15.0 * factor * tm, rel=1e-4)
 
     def test_scales_summary_dollar_fields(self):
         from copy import deepcopy
 
         data = deepcopy(COVERAGE_DATA)
-        result = _scale_coverage_data(data, 2.0)
+        result = _scale_coverage_data(data, 2.0, is_daily=False)
         assert result["compute"]["summary"]["avg_hourly_total"] == pytest.approx(33.0)
         assert result["compute"]["summary"]["est_monthly_total"] == pytest.approx(23760.0)
 
@@ -124,12 +156,58 @@ class TestScaleCoverageData:
         from copy import deepcopy
 
         data = deepcopy(COVERAGE_DATA)
-        result = _scale_coverage_data(data, 2.5)
+        result = _scale_coverage_data(data, 2.5, is_daily=False)
         assert result["compute"]["summary"]["avg_coverage_total"] == 66.7
 
     def test_skips_missing_sp_types(self):
-        result = _scale_coverage_data({"compute": {"timeseries": [], "summary": {}}}, 2.0)
+        result = _scale_coverage_data(
+            {"compute": {"timeseries": [], "summary": {}}}, 2.0, is_daily=False
+        )
         assert "database" not in result
+
+
+class TestApplyFakeCoverage:
+    def test_sets_flat_covered_line(self):
+        from copy import deepcopy
+
+        data = deepcopy(COVERAGE_DATA)
+        pcts = _apply_fake_coverage(data)
+        ts = data["compute"]["timeseries"]
+        assert ts[0]["covered"] == ts[1]["covered"]
+        assert 0.25 <= pcts["compute"] <= 0.75
+
+    def test_covered_within_expected_range(self):
+        from copy import deepcopy
+
+        data = deepcopy(COVERAGE_DATA)
+        _apply_fake_coverage(data)
+        min_total = min(p["total"] for p in data["compute"]["timeseries"])
+        covered = data["compute"]["timeseries"][0]["covered"]
+        assert min_total * 0.25 <= covered <= min_total * 0.75
+
+    def test_reuses_provided_percentages(self):
+        from copy import deepcopy
+
+        data = deepcopy(COVERAGE_DATA)
+        pcts = _apply_fake_coverage(data, coverage_pcts={"compute": 0.5})
+        covered = data["compute"]["timeseries"][0]["covered"]
+        min_total = min(p["total"] for p in data["compute"]["timeseries"])
+        assert covered == pytest.approx(min_total * 0.5)
+        assert pcts["compute"] == 0.5
+
+    def test_updates_summary(self):
+        from copy import deepcopy
+
+        data = deepcopy(COVERAGE_DATA)
+        _apply_fake_coverage(data, coverage_pcts={"compute": 0.5})
+        covered = data["compute"]["timeseries"][0]["covered"]
+        assert data["compute"]["summary"]["avg_hourly_covered"] == covered
+        assert data["compute"]["summary"]["est_monthly_covered"] == pytest.approx(covered * 720)
+
+    def test_skips_empty_timeseries(self):
+        data = {"database": {"timeseries": [], "summary": {}}}
+        pcts = _apply_fake_coverage(data)
+        assert "database" not in pcts
 
 
 class TestScaleSavingsData:
@@ -210,6 +288,14 @@ class TestRandomizeReportData:
 
         cov = deepcopy(COVERAGE_DATA)
         sav = deepcopy(SAVINGS_DATA)
-        c_out, _d_out, s_out = randomize_report_data(cov, cov, sav)
+        c_out, d_out, s_out = randomize_report_data(cov, cov, sav)
         assert c_out["compute"]["timeseries"][0]["covered"] != 10.0
         assert s_out["plans"][0]["plan_id"].startswith("demo-")
+        # Fake coverage produces a flat line
+        ts = c_out["compute"]["timeseries"]
+        assert ts[0]["covered"] == ts[1]["covered"]
+        # Hourly and daily share the same coverage percentage
+        assert (
+            d_out["compute"]["timeseries"][0]["covered"]
+            == d_out["compute"]["timeseries"][1]["covered"]
+        )


### PR DESCRIPTION
## Summary
- Reverts #227 to reintroduce the demo mode enhancements
- Time-based multipliers (1.5-2.5x): varies by hour-of-day for hourly data, day-of-week for daily data
- Fake SP coverage: flat line at random 25-75% of min-hourly total, consistent across hourly and daily charts