### PR TITLE
fix: fail explicitly on ambiguous offering query

### DIFF
--- a/lambda/scheduler/offering_resolver.py
+++ b/lambda/scheduler/offering_resolver.py
@@ -90,6 +90,17 @@ def resolve_offering(
     results = response.get("searchResults", [])
     if not results:
         raise ValueError(f"No offering found for {sp_type_key} / {term} / {payment_option}")
+    if len(results) > 1:
+        offering_ids = [r.get("offeringId", "?") for r in results]
+        raise ValueError(
+            f"Ambiguous offering query for {sp_type_key} / {term} / {payment_option}: "
+            f"got {len(results)} results, expected exactly 1.\n"
+            f"Offering IDs returned: {offering_ids}\n"
+            f"Query: planType={plan_type}, duration={duration}, "
+            f"paymentOption={api_payment_option}, productType={product_type}, currency=USD\n"
+            f"Please report this at: "
+            f"https://github.com/etiennechabert/terraform-aws-sp-autopilot/issues/new"
+        )
 
     result = results[0]
     offering_id = result["offeringId"]

--- a/lambda/scheduler/tests/unit/test_offering_resolver.py
+++ b/lambda/scheduler/tests/unit/test_offering_resolver.py
@@ -1,0 +1,60 @@
+"""Unit tests for offering resolver module."""
+
+from unittest.mock import MagicMock
+
+import offering_resolver
+import pytest
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+def _make_offering(offering_id="off-123", plan_type="Compute", product_types=None):
+    return {
+        "offeringId": offering_id,
+        "planType": plan_type,
+        "productTypes": product_types or ["Fargate"],
+        "description": "test",
+        "paymentOption": "No Upfront",
+        "durationSeconds": 31536000,
+        "usageType": "test",
+    }
+
+
+def test_resolve_single_offering(mock_client):
+    mock_client.describe_savings_plans_offerings.return_value = {
+        "searchResults": [_make_offering()],
+    }
+    result = offering_resolver.resolve_offering(mock_client, "compute", "ONE_YEAR", "NO_UPFRONT")
+    assert result["id"] == "off-123"
+
+
+def test_resolve_no_offering_raises(mock_client):
+    mock_client.describe_savings_plans_offerings.return_value = {"searchResults": []}
+    with pytest.raises(ValueError, match="No offering found"):
+        offering_resolver.resolve_offering(mock_client, "compute", "ONE_YEAR", "NO_UPFRONT")
+
+
+def test_resolve_ambiguous_offerings_raises(mock_client):
+    mock_client.describe_savings_plans_offerings.return_value = {
+        "searchResults": [_make_offering("off-1"), _make_offering("off-2")],
+    }
+    with pytest.raises(ValueError, match="Ambiguous offering query"):
+        offering_resolver.resolve_offering(mock_client, "compute", "ONE_YEAR", "NO_UPFRONT")
+
+
+def test_resolve_unknown_sp_type_raises(mock_client):
+    with pytest.raises(ValueError, match="Unknown sp_type_key"):
+        offering_resolver.resolve_offering(mock_client, "unknown", "ONE_YEAR", "NO_UPFRONT")
+
+
+def test_resolve_unknown_term_raises(mock_client):
+    with pytest.raises(ValueError, match="Unknown term"):
+        offering_resolver.resolve_offering(mock_client, "compute", "FIVE_YEAR", "NO_UPFRONT")
+
+
+def test_resolve_unknown_payment_option_raises(mock_client):
+    with pytest.raises(ValueError, match="Unknown payment_option"):
+        offering_resolver.resolve_offering(mock_client, "compute", "ONE_YEAR", "UNKNOWN")


### PR DESCRIPTION
## Summary
- After #239 fixed the offering resolution mappings, adds a safety guard to ensure `DescribeSavingsPlansOfferings` returns exactly one result
- If multiple offerings match, raises with full query context (parameters, offering IDs) and a link to report the issue on GitHub