### PR TITLE
feat(reporter): expandable row with full details in Active Plans table

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -336,6 +336,7 @@ resource "aws_iam_role_policy" "reporter_cost_explorer" {
       Action = [
         "ce:GetSavingsPlansPurchaseRecommendation",
         "ce:GetSavingsPlansUtilization",
+        "ce:GetSavingsPlansUtilizationDetails",
         "ce:GetSavingsPlansCoverage"
       ]
       Resource = "*"

--- a/lambda/reporter/handler.py
+++ b/lambda/reporter/handler.py
@@ -32,7 +32,7 @@ from shared.handler_utils import (
     send_error_notification,
 )
 from shared.local_mode import is_local_mode
-from shared.savings_plans_metrics import get_savings_plans_summary
+from shared.savings_plans_metrics import get_per_plan_mtd_metrics, get_savings_plans_summary
 from shared.spending_analyzer import SpendingAnalyzer
 from shared.storage_adapter import StorageAdapter
 
@@ -94,6 +94,13 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         get_enabled_plan_types(config),
         config["lookback_hours"],
     )
+
+    # Attach per-plan MTD metrics (by ARN) onto each plan for the details panel.
+    per_plan_mtd = get_per_plan_mtd_metrics(clients["ce"])
+    for plan in savings_data.get("plans", []):
+        arn = plan.get("savings_plan_arn")
+        if arn and arn in per_plan_mtd:
+            plan.update(per_plan_mtd[arn])
 
     logger.info(
         f"Data collected - Coverage: {coverage_data['compute']['summary']['avg_coverage_total']:.1f}%, "

--- a/lambda/reporter/html_report.py
+++ b/lambda/reporter/html_report.py
@@ -213,6 +213,29 @@ def generate_html_report(
         .expiring-soon:hover {{
             background-color: #ffe8a1 !important;
         }}
+        .active-plans-table .plan-summary-row {{
+            cursor: pointer;
+        }}
+        .active-plans-table .plan-toggle-cell {{
+            text-align: center;
+            color: #6c757d;
+            user-select: none;
+        }}
+        .active-plans-table .plan-toggle-icon {{
+            display: inline-block;
+            transition: transform 0.15s ease;
+        }}
+        .active-plans-table .plan-summary-row.expanded .plan-toggle-icon {{
+            transform: rotate(90deg);
+            color: #2196f3;
+        }}
+        .active-plans-table .plan-details-row > td {{
+            padding: 0;
+            border-bottom: 1px solid #e0e0e0;
+        }}
+        .active-plans-table .plan-details-row:hover {{
+            background: transparent;
+        }}
         .metric {{
             font-weight: bold;
             color: #232f3e;
@@ -841,6 +864,20 @@ def generate_html_report(
                         el.style.borderColor = palette.ondemandBorder;
                     }}
                 }});
+            }}
+        }}
+
+        // Active Plans: expand/collapse a row to show full plan details
+        function togglePlanDetails(detailsId, summaryRow) {{
+            const detailsRow = document.getElementById(detailsId);
+            if (!detailsRow) return;
+            const isHidden = detailsRow.hasAttribute('hidden');
+            if (isHidden) {{
+                detailsRow.removeAttribute('hidden');
+                summaryRow.classList.add('expanded');
+            }} else {{
+                detailsRow.setAttribute('hidden', '');
+                summaryRow.classList.remove('expanded');
             }}
         }}
 

--- a/lambda/reporter/html_report.py
+++ b/lambda/reporter/html_report.py
@@ -322,14 +322,13 @@ def generate_html_report(
             cursor: help;
             flex: 0 0 auto;
         }}
-        .plan-card-days {{
-            flex: 0 0 auto;
-            min-width: 90px;
-            text-align: right;
+        .plan-card-expiration {{
+            cursor: help;
             font-weight: 600;
             color: #232f3e;
-            cursor: help;
         }}
+        .plan-card-expiration.expiring {{ color: #b88400; }}
+        .plan-card-expiration.expired {{ color: #dc3545; }}
         .plan-card-details {{
             border-top: 1px solid #e6ebf2;
             background: #fafbfc;

--- a/lambda/reporter/html_report.py
+++ b/lambda/reporter/html_report.py
@@ -302,6 +302,19 @@ def generate_html_report(
             flex-wrap: wrap;
         }}
         .plan-card-sep {{ color: #c1c9d2; }}
+        .plan-card-pill {{
+            display: inline-flex;
+            align-items: center;
+            padding: 2px 10px;
+            border-radius: 12px;
+            background: #f1f4f8;
+            font-size: 0.82em;
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+            cursor: help;
+            flex: 0 0 auto;
+        }}
+        .plan-card-pill + .plan-card-pill {{ margin-left: 6px; }}
         .plan-card-id-short {{
             font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
             font-size: 0.78em;

--- a/lambda/reporter/html_report.py
+++ b/lambda/reporter/html_report.py
@@ -12,8 +12,7 @@ from typing import Any
 
 from chart_data import prepare_chart_and_preview_json
 from html_sections import (
-    build_active_plans_table_html,
-    build_breakdown_table_html,
+    build_plans_breakdown_section_html,
     build_raw_data_section_html,
     render_sp_type_tab_button,
     render_sp_type_tab_content,
@@ -213,29 +212,141 @@ def generate_html_report(
         .expiring-soon:hover {{
             background-color: #ffe8a1 !important;
         }}
-        .active-plans-table .plan-summary-row {{
+        .active-plans-table .plan-summary-row,
+        .breakdown-table .type-summary-row,
+        .breakdown-table .plan-summary-row {{
             cursor: pointer;
         }}
-        .active-plans-table .plan-toggle-cell {{
+        .active-plans-table .plan-toggle-cell,
+        .breakdown-table .plan-toggle-cell {{
             text-align: center;
             color: #6c757d;
             user-select: none;
         }}
-        .active-plans-table .plan-toggle-icon {{
+        .active-plans-table .plan-toggle-icon,
+        .breakdown-table .plan-toggle-icon {{
             display: inline-block;
             transition: transform 0.15s ease;
         }}
-        .active-plans-table .plan-summary-row.expanded .plan-toggle-icon {{
+        .active-plans-table .plan-summary-row.expanded .plan-toggle-icon,
+        .breakdown-table .type-summary-row.expanded .plan-toggle-icon,
+        .breakdown-table .plan-summary-row.expanded .plan-toggle-icon {{
             transform: rotate(90deg);
             color: #2196f3;
         }}
-        .active-plans-table .plan-details-row > td {{
+        .active-plans-table .plan-details-row > td,
+        .breakdown-table .plan-details-row > td {{
             padding: 0;
             border-bottom: 1px solid #e0e0e0;
         }}
-        .active-plans-table .plan-details-row:hover {{
+        .active-plans-table .plan-details-row:hover,
+        .breakdown-table .plan-details-row:hover {{
             background: transparent;
         }}
+        .breakdown-table .type-summary-row.expanded {{
+            background-color: #f0f4fa;
+        }}
+        /* Nested plan cards inside an expanded type row */
+        .plans-nested-wrap {{
+            padding: 10px 20px 14px 44px;
+            background: linear-gradient(180deg, #fafbfc 0%, #fafbfc 100%);
+            border-top: 1px solid #e6ebf2;
+        }}
+        .plan-card {{
+            margin-bottom: 6px;
+            border-radius: 6px;
+            border: 1px solid #e6ebf2;
+            background: #ffffff;
+            overflow: hidden;
+        }}
+        .plan-card:last-child {{ margin-bottom: 0; }}
+        .plan-card-row {{
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 8px 14px;
+            cursor: pointer;
+            font-size: 0.92em;
+            transition: background 0.1s ease;
+        }}
+        .plan-card-row:hover {{ background: #f5f8fb; }}
+        .plan-card-row.expanded {{ background: #eef4fa; }}
+        .plan-card-row.expiring-soon {{
+            background: #fff9e6;
+            border-left: 3px solid #ffc107;
+        }}
+        .plan-card-row .plan-toggle-icon {{
+            color: #6c757d;
+            display: inline-block;
+            transition: transform 0.15s ease;
+            flex: 0 0 auto;
+        }}
+        .plan-card-row.expanded .plan-toggle-icon {{
+            transform: rotate(90deg);
+            color: #2196f3;
+        }}
+        .plan-card-id {{
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 0.82em;
+            color: #232f3e;
+            flex: 1 1 auto;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }}
+        .plan-card-meta {{
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            color: #495564;
+            font-size: 0.9em;
+            flex: 0 0 auto;
+        }}
+        .plan-card-commit {{
+            color: #232f3e;
+            font-weight: 600;
+        }}
+        .plan-card-sep {{ color: #c1c9d2; }}
+        .plan-card-days {{
+            flex: 0 0 auto;
+            min-width: 90px;
+            text-align: right;
+            font-weight: 600;
+            color: #232f3e;
+            cursor: help;
+        }}
+        .plan-card-details {{
+            border-top: 1px solid #e6ebf2;
+            background: #fafbfc;
+            padding: 14px 18px;
+        }}
+        /* Details panel (inside plan-card-details) */
+        .plan-details-panel {{ padding: 0; }}
+        .plan-details-kv {{
+            width: 100%;
+            margin: 0;
+            border-collapse: collapse;
+            background: transparent;
+        }}
+        .plan-details-kv th {{
+            width: 180px;
+            text-align: left;
+            background: transparent;
+            color: #6c757d;
+            font-weight: 500;
+            font-size: 0.85em;
+            padding: 5px 10px 5px 0;
+            border-bottom: 1px solid #eef1f5;
+        }}
+        .plan-details-kv td {{
+            padding: 5px 0;
+            word-break: break-all;
+            color: #232f3e;
+            font-size: 0.9em;
+            border-bottom: 1px solid #eef1f5;
+        }}
+        .plan-details-kv tr:last-child th,
+        .plan-details-kv tr:last-child td {{ border-bottom: none; }}
         .metric {{
             font-weight: bold;
             color: #232f3e;
@@ -724,23 +835,20 @@ def generate_html_report(
         <div class="section">
             <h2>Existing Savings Plans</h2>
 
-            <h3 style="color: #232f3e; margin-top: 25px; margin-bottom: 15px; font-size: 1.2em;">Breakdown by Type</h3>
+            <p style="color: #6c757d; font-size: 0.9em; margin-top: 0; margin-bottom: 15px;">
+                Click a plan type to see its active plans; click an individual plan to see full details.
+            </p>
 """
 
-    html += build_breakdown_table_html(
+    plans = savings_data.get("plans", [])
+    html += build_plans_breakdown_section_html(
         breakdown_by_type,
+        plans,
         plans_count,
         average_utilization,
         total_commitment,
         savings_percentage,
     )
-
-    html += """
-            <h3 style="color: #232f3e; margin-top: 35px; margin-bottom: 15px; font-size: 1.2em;">Active Plans Details</h3>
-"""
-
-    plans = savings_data.get("plans", [])
-    html += build_active_plans_table_html(plans)
 
     monthly_savings = net_savings_hourly * 24 * 30
     html += build_raw_data_section_html(raw_data, report_timestamp, monthly_savings)
@@ -1176,33 +1284,70 @@ def generate_html_report(
         }}
 
         // Function to create daily chart (simplified - no annotation lines)
-        function createDailyChart(canvasId, chartData, title) {{
+        function createDailyChart(canvasId, chartData, title, spType) {{
             const ctx = document.getElementById(canvasId);
-            _injectChartHeader(canvasId, title, null);
+            _injectChartHeader(canvasId, title, spType || null);
             const palette = colorPalettes['palette1'];
+
+            // Build "added by next purchase" dataset: hourly $/hr added scaled to daily ($/day),
+            // clamped per-day so it never exceeds that day's on-demand cost.
+            const futureTargetData = spType ? configuredTargetData[spType] : null;
+            let futureData = null;
+            if (futureTargetData) {{
+                const addedOdPerDay = (futureTargetData.added_od_equiv || 0) * 24;
+                if (addedOdPerDay > 0) {{
+                    futureData = chartData.ondemand.map(function(od) {{
+                        return Math.min(addedOdPerDay, od);
+                    }});
+                }}
+            }}
+
+            const datasets = [
+                {{
+                    label: 'Existing SP Commitment',
+                    data: chartData.covered,
+                    backgroundColor: palette.covered,
+                    borderColor: palette.coveredBorder,
+                    borderWidth: 1,
+                    stack: 'stack0'
+                }}
+            ];
+            if (futureData) {{
+                datasets.push({{
+                    label: 'Added by next purchase',
+                    data: futureData,
+                    backgroundColor: palette.configuredTarget,
+                    borderColor: palette.configuredTarget,
+                    borderWidth: 1,
+                    stack: 'stack0'
+                }});
+                const adjustedOndemand = chartData.ondemand.map(function(od, i) {{
+                    return Math.max(0, od - futureData[i]);
+                }});
+                datasets.push({{
+                    label: 'On-Demand Cost',
+                    data: adjustedOndemand,
+                    backgroundColor: palette.ondemand,
+                    borderColor: palette.ondemandBorder,
+                    borderWidth: 1,
+                    stack: 'stack0'
+                }});
+            }} else {{
+                datasets.push({{
+                    label: 'On-Demand Cost',
+                    data: chartData.ondemand,
+                    backgroundColor: palette.ondemand,
+                    borderColor: palette.ondemandBorder,
+                    borderWidth: 1,
+                    stack: 'stack0'
+                }});
+            }}
 
             chartInstances[canvasId] = new Chart(ctx, {{
                 type: 'bar',
                 data: {{
                     labels: chartData.labels,
-                    datasets: [
-                        {{
-                            label: 'Existing SP Commitment',
-                            data: chartData.covered,
-                            backgroundColor: palette.covered,
-                            borderColor: palette.coveredBorder,
-                            borderWidth: 1,
-                            stack: 'stack0'
-                        }},
-                        {{
-                            label: 'On-Demand Cost',
-                            data: chartData.ondemand,
-                            backgroundColor: palette.ondemand,
-                            borderColor: palette.ondemandBorder,
-                            borderWidth: 1,
-                            stack: 'stack0'
-                        }}
-                    ]
+                    datasets: datasets
                 }},
                 options: {{
                     responsive: true,
@@ -1433,15 +1578,15 @@ def generate_html_report(
             const dailyDays = dailyChartData.global.labels.length;
             {"createDailyChart('globalDailyChart', dailyChartData.global, 'Daily Usage: On-Demand vs Covered (All Types) - ' + dailyDays + ' days'); document.getElementById('global-daily-container').style.display = '';" if show_global_tab else "// Global daily chart skipped (single type enabled)"}
             if (document.getElementById('computeDailyChart')) {{
-                createDailyChart('computeDailyChart', dailyChartData.compute, 'Compute Savings Plans - Daily Usage (' + dailyChartData.compute.labels.length + ' days)');
+                createDailyChart('computeDailyChart', dailyChartData.compute, 'Compute Savings Plans - Daily Usage (' + dailyChartData.compute.labels.length + ' days)', 'compute');
                 document.getElementById('compute-daily-container').style.display = '';
             }}
             if (document.getElementById('databaseDailyChart')) {{
-                createDailyChart('databaseDailyChart', dailyChartData.database, 'Database Savings Plans - Daily Usage (' + dailyChartData.database.labels.length + ' days)');
+                createDailyChart('databaseDailyChart', dailyChartData.database, 'Database Savings Plans - Daily Usage (' + dailyChartData.database.labels.length + ' days)', 'database');
                 document.getElementById('database-daily-container').style.display = '';
             }}
             if (document.getElementById('sagemakerDailyChart')) {{
-                createDailyChart('sagemakerDailyChart', dailyChartData.sagemaker, 'SageMaker Savings Plans - Daily Usage (' + dailyChartData.sagemaker.labels.length + ' days)');
+                createDailyChart('sagemakerDailyChart', dailyChartData.sagemaker, 'SageMaker Savings Plans - Daily Usage (' + dailyChartData.sagemaker.labels.length + ' days)', 'sagemaker');
                 document.getElementById('sagemaker-daily-container').style.display = '';
             }}
         }}

--- a/lambda/reporter/html_report.py
+++ b/lambda/reporter/html_report.py
@@ -285,28 +285,30 @@ def generate_html_report(
             transform: rotate(90deg);
             color: #2196f3;
         }}
-        .plan-card-id {{
-            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-            font-size: 0.82em;
+        .plan-card-commit {{
             color: #232f3e;
-            flex: 1 1 auto;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            font-weight: 700;
+            font-size: 1.02em;
+            min-width: 92px;
+            flex: 0 0 auto;
         }}
         .plan-card-meta {{
             display: flex;
             gap: 8px;
             align-items: center;
             color: #495564;
-            font-size: 0.9em;
-            flex: 0 0 auto;
-        }}
-        .plan-card-commit {{
-            color: #232f3e;
-            font-weight: 600;
+            font-size: 0.92em;
+            flex: 1 1 auto;
+            flex-wrap: wrap;
         }}
         .plan-card-sep {{ color: #c1c9d2; }}
+        .plan-card-id-short {{
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 0.78em;
+            color: #94a0ae;
+            cursor: help;
+            flex: 0 0 auto;
+        }}
         .plan-card-days {{
             flex: 0 0 auto;
             min-width: 90px;

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -631,7 +631,7 @@ def _build_type_plans_subtable(
         end_date = plan.get("end_date", "") or ""
 
         (
-            start_display,
+            _start_display,
             _end_display,
             days_remaining_display,
             expiring_soon,
@@ -644,15 +644,19 @@ def _build_type_plans_subtable(
         summary_class_attr = " ".join(summary_classes)
         details_id = f"plan-details-{type_idx}-{plan_idx}"
 
+        expiration_phrase = _expiration_phrase(days_remaining_display)
+        expiration_class = "plan-card-expiration"
+        if days_remaining_display == "Expired":
+            expiration_class += " expired"
+        elif expiring_soon:
+            expiration_class += " expiring"
+
         meta_parts = [
-            f"{term_years}&nbsp;year",
-            payment_option,
+            f"<span>{term_years}&nbsp;year</span>",
+            f"<span>{payment_option}</span>",
+            (f'<span class="{expiration_class}" title="{tooltip_text}">{expiration_phrase}</span>'),
         ]
-        if start_display and start_display != "Unknown":
-            meta_parts.append(f"started {start_display}")
-        meta_html = '<span class="plan-card-sep">·</span>'.join(
-            f"<span>{part}</span>" for part in meta_parts
-        )
+        meta_html = '<span class="plan-card-sep">·</span>'.join(meta_parts)
 
         short_id_html = ""
         if plan_id and plan_id != "Unknown" and len(plan_id) > 6:
@@ -670,7 +674,6 @@ def _build_type_plans_subtable(
                             <span class="plan-card-meta">{meta_html}</span>
                             {metrics_html}
                             {short_id_html}
-                            <span class="plan-card-days" title="{tooltip_text}">{days_remaining_display}</span>
                         </div>
                         <div id="{details_id}" class="plan-card-details" hidden>{_render_plan_details(plan)}</div>
                     </div>
@@ -815,6 +818,17 @@ def _render_plan_details(plan: dict[str, Any]) -> str:
         '<table class="plan-details-kv">'
         "<tbody>" + "".join(rows) + "</tbody></table></div>"
     )
+
+
+def _expiration_phrase(days_remaining_display: str) -> str:
+    """Natural phrasing for the expiration meta chunk on a plan card."""
+    if days_remaining_display in ("Expired", "Today", "N/A"):
+        return (
+            days_remaining_display.lower()
+            if days_remaining_display == "Expired"
+            else ("expires today" if days_remaining_display == "Today" else days_remaining_display)
+        )
+    return f"{days_remaining_display} left"
 
 
 def _render_plan_card_metrics(plan: dict[str, Any]) -> str:

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -827,12 +827,15 @@ def _render_plan_card_metrics(plan: dict[str, Any]) -> str:
 
     utilization_pct = plan.get("mtd_utilization_percentage", 0.0) or 0.0
     discount_pct = plan.get("discount_percentage", 0.0) or 0.0
+    net_savings = plan.get("mtd_net_savings", 0.0) or 0.0
 
     util_color = (
         "#28a745" if utilization_pct >= 95 else "#ff9900" if utilization_pct >= 80 else "#dc3545"
     )
 
     return (
+        f'<span class="plan-card-pill" style="color: #28a745;" '
+        f'title="MTD net savings">save ${net_savings:,.0f}</span>'
         f'<span class="plan-card-pill" style="color: {util_color};" '
         f'title="MTD utilization">util {utilization_pct:.0f}%</span>'
         f'<span class="plan-card-pill" style="color: #2196f3;" '

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -623,15 +623,15 @@ def _build_type_plans_subtable(
 
     items = ""
     for plan_idx, plan in enumerate(sorted_plans):
-        plan_id = plan.get("plan_id", "Unknown")
+        plan_id = plan.get("plan_id", "") or ""
         hourly_commitment = plan.get("hourly_commitment", 0.0)
         term_years = plan.get("term_years", 0)
         payment_option = plan.get("payment_option", "Unknown")
-        start_date = plan.get("start_date", "Unknown")
-        end_date = plan.get("end_date", "Unknown")
+        start_date = plan.get("start_date", "") or ""
+        end_date = plan.get("end_date", "") or ""
 
         (
-            _start_display,
+            start_display,
             _end_display,
             days_remaining_display,
             expiring_soon,
@@ -644,18 +644,29 @@ def _build_type_plans_subtable(
         summary_class_attr = " ".join(summary_classes)
         details_id = f"plan-details-{type_idx}-{plan_idx}"
 
+        meta_parts = [
+            f"{term_years}&nbsp;year",
+            payment_option,
+        ]
+        if start_display and start_display != "Unknown":
+            meta_parts.append(f"started {start_display}")
+        meta_html = '<span class="plan-card-sep">·</span>'.join(
+            f"<span>{part}</span>" for part in meta_parts
+        )
+
+        short_id_html = ""
+        if plan_id and plan_id != "Unknown" and len(plan_id) > 6:
+            short_id_html = (
+                f'<span class="plan-card-id-short" title="{plan_id}">…{plan_id[-5:]}</span>'
+            )
+
         items += f"""
                     <div class="plan-card">
                         <div class="{summary_class_attr}" onclick="togglePlanDetails('{details_id}', this)">
                             <span class="plan-toggle-icon">&#9656;</span>
-                            <span class="plan-card-id">{plan_id}</span>
-                            <span class="plan-card-meta">
-                                <span class="plan-card-commit">${hourly_commitment:.2f}/hr</span>
-                                <span class="plan-card-sep">·</span>
-                                <span>{term_years}&nbsp;year</span>
-                                <span class="plan-card-sep">·</span>
-                                <span>{payment_option}</span>
-                            </span>
+                            <span class="plan-card-commit">${hourly_commitment:.2f}/hr</span>
+                            <span class="plan-card-meta">{meta_html}</span>
+                            {short_id_html}
                             <span class="plan-card-days" title="{tooltip_text}">{days_remaining_display}</span>
                         </div>
                         <div id="{details_id}" class="plan-card-details" hidden>{_render_plan_details(plan)}</div>

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -384,7 +384,7 @@ def parse_plan_dates(
 
 
 def build_active_plans_table_html(plans: list[dict[str, Any]]) -> str:
-    """Table of active Savings Plans sorted by end date."""
+    """Table of active Savings Plans sorted by end date, with expandable detail rows."""
     if not plans:
         return """
             <div class="no-data">No active Savings Plans found</div>
@@ -395,21 +395,22 @@ def build_active_plans_table_html(plans: list[dict[str, Any]]) -> str:
     three_months_from_now = now + timedelta(days=90)
 
     html = """
-            <table>
+            <table class="active-plans-table">
                 <thead>
                     <tr>
-                        <th style="width: 30%;">Plan ID</th>
+                        <th style="width: 3%;"></th>
+                        <th style="width: 28%;">Plan ID</th>
                         <th style="width: 12%;">Type</th>
                         <th style="width: 16%;">Hourly Commitment</th>
-                        <th style="width: 10%;">Term</th>
-                        <th style="width: 16%;">Payment Option</th>
-                        <th style="width: 16%; text-align: right;">Days Remaining</th>
+                        <th style="width: 9%;">Term</th>
+                        <th style="width: 15%;">Payment Option</th>
+                        <th style="width: 17%; text-align: right;">Days Remaining</th>
                     </tr>
                 </thead>
                 <tbody>
 """
 
-    for plan in sorted_plans:
+    for idx, plan in enumerate(sorted_plans):
         plan_id = plan.get("plan_id", "Unknown")
         plan_type = plan.get("plan_type", "Unknown")
         hourly_commitment = plan.get("hourly_commitment", 0.0)
@@ -426,16 +427,24 @@ def build_active_plans_table_html(plans: list[dict[str, Any]]) -> str:
             tooltip_text,
         ) = parse_plan_dates(start_date, end_date, now, three_months_from_now)
 
-        row_class = 'class="expiring-soon"' if expiring_soon else ""
+        summary_classes = ["plan-summary-row"]
+        if expiring_soon:
+            summary_classes.append("expiring-soon")
+        summary_class_attr = " ".join(summary_classes)
+        details_id = f"plan-details-{idx}"
 
         html += f"""
-                    <tr {row_class}>
+                    <tr class="{summary_class_attr}" onclick="togglePlanDetails('{details_id}', this)">
+                        <td class="plan-toggle-cell"><span class="plan-toggle-icon">&#9656;</span></td>
                         <td style="font-family: monospace; font-size: 0.8em; word-break: break-all;">{plan_id}</td>
                         <td>{plan_type}</td>
                         <td class="metric">${hourly_commitment:.2f}/hr</td>
                         <td>{term_years} year(s)</td>
                         <td>{payment_option}</td>
                         <td class="metric" title="{tooltip_text}" style="cursor: help; text-align: right;">{days_remaining_display}</td>
+                    </tr>
+                    <tr id="{details_id}" class="plan-details-row" hidden>
+                        <td colspan="7">{_render_plan_details(plan)}</td>
                     </tr>
 """
 
@@ -444,6 +453,90 @@ def build_active_plans_table_html(plans: list[dict[str, Any]]) -> str:
             </table>
 """
     return html
+
+
+def _render_plan_details(plan: dict[str, Any]) -> str:
+    """Render the expanded details panel for a single plan."""
+    savings_plan_arn = plan.get("savings_plan_arn") or ""
+    offering_id = plan.get("offering_id") or ""
+    description = plan.get("description") or ""
+    state = plan.get("state") or ""
+    currency = plan.get("currency") or "USD"
+    upfront = plan.get("upfront_payment_amount", 0.0) or 0.0
+    recurring = plan.get("recurring_payment_amount", 0.0) or 0.0
+    term_seconds = plan.get("term_seconds", 0) or 0
+    returnable_until = plan.get("returnable_until") or ""
+    product_types = plan.get("product_types") or []
+    tags = plan.get("tags") or {}
+    start_date = plan.get("start_date") or ""
+    end_date = plan.get("end_date") or ""
+
+    def _row(label: str, value: str) -> str:
+        return (
+            f'<tr><th style="width: 220px; text-align: left; background: #f8f9fa; '
+            f'color: #232f3e; padding: 6px 12px;">{label}</th>'
+            f'<td style="padding: 6px 12px; word-break: break-all;">{value}</td></tr>'
+        )
+
+    rows: list[str] = []
+
+    if description:
+        rows.append(_row("Description", description))
+    if state:
+        rows.append(_row("State", state))
+    rows.append(_row("Start", start_date))
+    rows.append(_row("End", end_date))
+    if term_seconds:
+        rows.append(_row("Term Duration", f"{term_seconds:,} seconds"))
+    rows.append(_row("Commitment", f"{currency} {plan.get('hourly_commitment', 0.0):.5f}/hour"))
+    rows.append(_row("Upfront Payment", f"{currency} {upfront:,.2f}"))
+    rows.append(_row("Recurring Payment", f"{currency} {recurring:,.5f}/hour"))
+    if product_types:
+        chips = "".join(
+            f'<span style="display: inline-block; background: #e8eef7; color: #232f3e; '
+            f'padding: 2px 10px; border-radius: 12px; margin: 2px 4px 2px 0; font-size: 0.85em;">'
+            f"{pt}</span>"
+            for pt in product_types
+        )
+        rows.append(_row("Covered Products", chips))
+    if returnable_until:
+        rows.append(_row("Returnable Until", returnable_until))
+    if savings_plan_arn:
+        rows.append(
+            _row(
+                "ARN",
+                f'<code style="font-size: 0.85em;">{savings_plan_arn}</code>',
+            )
+        )
+    if offering_id:
+        rows.append(
+            _row(
+                "Offering ID",
+                f'<code style="font-size: 0.85em;">{offering_id}</code>',
+            )
+        )
+
+    if tags:
+        tag_rows = "".join(
+            f'<tr><td style="padding: 2px 8px; font-family: monospace; font-size: 0.85em; '
+            f'color: #555;">{k}</td>'
+            f'<td style="padding: 2px 8px; font-family: monospace; font-size: 0.85em;">{v}</td></tr>'
+            for k, v in tags.items()
+        )
+        tag_table = (
+            '<table style="width: auto; margin: 0; border-collapse: collapse;">'
+            f"<tbody>{tag_rows}</tbody></table>"
+        )
+        rows.append(_row("Tags", tag_table))
+    else:
+        rows.append(_row("Tags", '<em style="color: #6c757d;">none</em>'))
+
+    return (
+        '<div class="plan-details-panel" style="background: #fcfcfc; '
+        'padding: 14px 20px; border-left: 3px solid #2196f3;">'
+        '<table style="width: 100%; margin: 0; border-collapse: collapse;">'
+        "<tbody>" + "".join(rows) + "</tbody></table></div>"
+    )
 
 
 def render_spike_guard_warning_banner(

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -199,6 +199,7 @@ def build_breakdown_table_html(
                         <th>Commitment/hr</th>
                         <th>On-Demand Covered/hr</th>
                         <th>Savings/hr</th>
+                        <th>Savings %</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -237,6 +238,7 @@ def build_breakdown_table_html(
                         <td class="metric">${total_commitment_type:.2f}/hr</td>
                         <td class="metric">${on_demand_coverage_capacity:.2f}/hr</td>
                         <td class="metric" style="color: #28a745;">${potential_savings:.2f}/hr</td>
+                        <td class="metric" style="color: #28a745;">{type_savings_pct:.1f}%</td>
                     </tr>
 """
         else:
@@ -247,6 +249,7 @@ def build_breakdown_table_html(
                         <td>{plans_count_type}</td>
                         <td class="metric">{na_html}</td>
                         <td class="metric">${total_commitment_type:.2f}/hr</td>
+                        <td class="metric">{na_html}</td>
                         <td class="metric">{na_html}</td>
                         <td class="metric">{na_html}</td>
                     </tr>
@@ -265,6 +268,7 @@ def build_breakdown_table_html(
                         <td class="metric">${total_commitment:.2f}/hr</td>
                         <td class="metric">${total_coverage_capacity:.2f}/hr</td>
                         <td class="metric" style="color: #28a745;">${total_potential_savings:.2f}/hr</td>
+                        <td class="metric" style="color: #28a745;">{overall_savings_percentage:.1f}%</td>
                     </tr>
 """
 
@@ -455,6 +459,268 @@ def build_active_plans_table_html(plans: list[dict[str, Any]]) -> str:
     return html
 
 
+def build_plans_breakdown_section_html(
+    breakdown_by_type: dict[str, Any],
+    plans: list[dict[str, Any]],
+    plans_count: int,
+    average_utilization: float,
+    total_commitment: float,
+    overall_savings_percentage: float,
+) -> str:
+    """Nested breakdown table: plan type -> plans of that type -> full plan details.
+
+    Two levels of click-to-expand: the type row opens a nested sub-table of
+    that type's active plans; each plan row then opens its full details panel.
+    """
+    if not breakdown_by_type:
+        return ""
+
+    now = datetime.now(UTC)
+    three_months_from_now = now + timedelta(days=90)
+
+    plans_by_type: dict[str, list[dict[str, Any]]] = {}
+    for plan in plans:
+        plans_by_type.setdefault(plan.get("plan_type", "Unknown"), []).append(plan)
+
+    na_tooltip = "This SP type is not enabled in your configuration, so metrics are not collected"
+
+    html = """
+            <table class="breakdown-table">
+                <thead>
+                    <tr>
+                        <th style="width: 3%;"></th>
+                        <th>Plan Type</th>
+                        <th>Active Plans</th>
+                        <th>Utilization</th>
+                        <th>Commitment/hr</th>
+                        <th>On-Demand Covered/hr</th>
+                        <th>Savings/hr</th>
+                        <th>Savings %</th>
+                        <th style="text-align: right;">Next Expiry</th>
+                    </tr>
+                </thead>
+                <tbody>
+"""
+
+    soonest_overall_days: int | None = None
+    soonest_overall_date: str = ""
+
+    for type_idx, (plan_type, type_data) in enumerate(breakdown_by_type.items()):
+        plans_count_type = type_data.get("plans_count", 0)
+        total_commitment_type = type_data.get("total_commitment", 0.0)
+        has_metrics = "average_utilization" in type_data
+
+        if "Compute" in plan_type:
+            plan_type_display = "Compute Savings Plans"
+        elif "SageMaker" in plan_type:
+            plan_type_display = "SageMaker Savings Plans"
+        elif "Database" in plan_type:
+            plan_type_display = "Database Savings Plans"
+        elif "EC2Instance" in plan_type:
+            plan_type_display = "EC2 Instance Savings Plans"
+        else:
+            plan_type_display = plan_type
+
+        type_plans = plans_by_type.get(plan_type, [])
+        next_expiry_cell = _render_next_expiry_cell(type_plans, now, three_months_from_now)
+        next_expiry_days = _next_expiry_days(type_plans, now)
+        if next_expiry_days is not None and (
+            soonest_overall_days is None or next_expiry_days < soonest_overall_days
+        ):
+            soonest_overall_days = next_expiry_days
+            soonest_overall_date = _next_expiry_end(type_plans)
+
+        type_details_id = f"type-plans-{type_idx}"
+
+        if has_metrics:
+            type_utilization = type_data["average_utilization"]
+            type_savings_pct = type_data.get("savings_percentage", 0.0)
+            on_demand_coverage_capacity = sp_calculations.coverage_from_commitment(
+                total_commitment_type, type_savings_pct
+            )
+            potential_savings = on_demand_coverage_capacity - total_commitment_type
+
+            html += f"""
+                    <tr class="type-summary-row" onclick="togglePlanDetails('{type_details_id}', this)">
+                        <td class="plan-toggle-cell"><span class="plan-toggle-icon">&#9656;</span></td>
+                        <td><strong>{plan_type_display}</strong></td>
+                        <td>{plans_count_type}</td>
+                        <td class="metric">{type_utilization:.1f}%</td>
+                        <td class="metric">${total_commitment_type:.2f}/hr</td>
+                        <td class="metric">${on_demand_coverage_capacity:.2f}/hr</td>
+                        <td class="metric" style="color: #28a745;">${potential_savings:.2f}/hr</td>
+                        <td class="metric" style="color: #28a745;">{type_savings_pct:.1f}%</td>
+                        <td class="metric" style="text-align: right;">{next_expiry_cell}</td>
+                    </tr>
+"""
+        else:
+            na_html = f'<span title="{na_tooltip}" style="cursor: help; color: #6c757d;">N/A</span>'
+            html += f"""
+                    <tr class="type-summary-row" onclick="togglePlanDetails('{type_details_id}', this)">
+                        <td class="plan-toggle-cell"><span class="plan-toggle-icon">&#9656;</span></td>
+                        <td><strong>{plan_type_display}</strong></td>
+                        <td>{plans_count_type}</td>
+                        <td class="metric">{na_html}</td>
+                        <td class="metric">${total_commitment_type:.2f}/hr</td>
+                        <td class="metric">{na_html}</td>
+                        <td class="metric">{na_html}</td>
+                        <td class="metric">{na_html}</td>
+                        <td class="metric" style="text-align: right;">{next_expiry_cell}</td>
+                    </tr>
+"""
+        # Nested sub-table with plans of this type, hidden by default.
+        nested = _build_type_plans_subtable(type_idx, type_plans, now, three_months_from_now)
+        html += f"""
+                    <tr id="{type_details_id}" class="plan-details-row" hidden>
+                        <td colspan="9" style="padding: 0;">{nested}</td>
+                    </tr>
+"""
+
+    if len(breakdown_by_type) > 1:
+        total_coverage_capacity = sp_calculations.coverage_from_commitment(
+            total_commitment, overall_savings_percentage
+        )
+        total_potential_savings = total_coverage_capacity - total_commitment
+        if soonest_overall_days is not None:
+            total_expiry_cell = _format_days_cell(soonest_overall_days, soonest_overall_date)
+        else:
+            total_expiry_cell = '<span style="color: #6c757d;">N/A</span>'
+        html += f"""
+                    <tr style="border-top: 2px solid #232f3e; font-weight: bold; background-color: #f8f9fa;">
+                        <td></td>
+                        <td><strong>Total</strong></td>
+                        <td>{plans_count}</td>
+                        <td class="metric">{average_utilization:.1f}%</td>
+                        <td class="metric">${total_commitment:.2f}/hr</td>
+                        <td class="metric">${total_coverage_capacity:.2f}/hr</td>
+                        <td class="metric" style="color: #28a745;">${total_potential_savings:.2f}/hr</td>
+                        <td class="metric" style="color: #28a745;">{overall_savings_percentage:.1f}%</td>
+                        <td class="metric" style="text-align: right;">{total_expiry_cell}</td>
+                    </tr>
+"""
+
+    html += """
+                </tbody>
+            </table>
+"""
+    return html
+
+
+def _build_type_plans_subtable(
+    type_idx: int,
+    type_plans: list[dict[str, Any]],
+    now: datetime,
+    three_months_from_now: datetime,
+) -> str:
+    """Collapsible card list of individual plans for one SP type."""
+    if not type_plans:
+        return (
+            '<div class="plans-nested-wrap" style="color: #6c757d; font-style: italic;">'
+            "No active plans for this type.</div>"
+        )
+
+    sorted_plans = sorted(type_plans, key=lambda p: p.get("end_date", "9999-12-31"))
+
+    items = ""
+    for plan_idx, plan in enumerate(sorted_plans):
+        plan_id = plan.get("plan_id", "Unknown")
+        hourly_commitment = plan.get("hourly_commitment", 0.0)
+        term_years = plan.get("term_years", 0)
+        payment_option = plan.get("payment_option", "Unknown")
+        start_date = plan.get("start_date", "Unknown")
+        end_date = plan.get("end_date", "Unknown")
+
+        (
+            _start_display,
+            _end_display,
+            days_remaining_display,
+            expiring_soon,
+            tooltip_text,
+        ) = parse_plan_dates(start_date, end_date, now, three_months_from_now)
+
+        summary_classes = ["plan-card-row"]
+        if expiring_soon:
+            summary_classes.append("expiring-soon")
+        summary_class_attr = " ".join(summary_classes)
+        details_id = f"plan-details-{type_idx}-{plan_idx}"
+
+        items += f"""
+                    <div class="plan-card">
+                        <div class="{summary_class_attr}" onclick="togglePlanDetails('{details_id}', this)">
+                            <span class="plan-toggle-icon">&#9656;</span>
+                            <span class="plan-card-id">{plan_id}</span>
+                            <span class="plan-card-meta">
+                                <span class="plan-card-commit">${hourly_commitment:.2f}/hr</span>
+                                <span class="plan-card-sep">·</span>
+                                <span>{term_years}&nbsp;year</span>
+                                <span class="plan-card-sep">·</span>
+                                <span>{payment_option}</span>
+                            </span>
+                            <span class="plan-card-days" title="{tooltip_text}">{days_remaining_display}</span>
+                        </div>
+                        <div id="{details_id}" class="plan-card-details" hidden>{_render_plan_details(plan)}</div>
+                    </div>
+"""
+
+    return f"""
+                <div class="plans-nested-wrap">
+                    {items}
+                </div>
+"""
+
+
+def _next_expiry_days(type_plans: list[dict[str, Any]], now: datetime) -> int | None:
+    """Days until the soonest-ending plan in the given list, or None if no parseable dates."""
+    soonest: int | None = None
+    for plan in type_plans:
+        end_date = plan.get("end_date", "") or ""
+        try:
+            if "T" in end_date:
+                end_parsed = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
+            else:
+                end_parsed = datetime.strptime(end_date, "%Y-%m-%d").replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            continue
+        days = (end_parsed - now).days
+        if soonest is None or days < soonest:
+            soonest = days
+    return soonest
+
+
+def _next_expiry_end(type_plans: list[dict[str, Any]]) -> str:
+    """End date of the soonest-expiring plan (used for tooltip)."""
+    if not type_plans:
+        return ""
+    sorted_plans = sorted(type_plans, key=lambda p: p.get("end_date", "9999-12-31"))
+    return sorted_plans[0].get("end_date", "") or ""
+
+
+def _render_next_expiry_cell(
+    type_plans: list[dict[str, Any]], now: datetime, three_months_from_now: datetime
+) -> str:
+    """Render the Next Expiry cell for a type row: days + color when <90 days out."""
+    days = _next_expiry_days(type_plans, now)
+    if days is None:
+        return '<span style="color: #6c757d;">N/A</span>'
+    end_date = _next_expiry_end(type_plans)
+    return _format_days_cell(days, end_date)
+
+
+def _format_days_cell(days: int, end_date: str) -> str:
+    if days < 0:
+        text, color = "Expired", "#dc3545"
+    elif days == 0:
+        text, color = "Today", "#dc3545"
+    elif days <= 30:
+        text, color = f"{days} days", "#dc3545"
+    elif days <= 90:
+        text, color = f"{days} days", "#ffc107"
+    else:
+        text, color = f"{days} days", "#232f3e"
+    tooltip = f"Next plan ends: {end_date.split('T', 1)[0]}" if end_date else ""
+    return f'<span title="{tooltip}" style="cursor: help; color: {color};">{text}</span>'
+
+
 def _render_plan_details(plan: dict[str, Any]) -> str:
     """Render the expanded details panel for a single plan."""
     savings_plan_arn = plan.get("savings_plan_arn") or ""
@@ -472,11 +738,9 @@ def _render_plan_details(plan: dict[str, Any]) -> str:
     end_date = plan.get("end_date") or ""
 
     def _row(label: str, value: str) -> str:
-        return (
-            f'<tr><th style="width: 220px; text-align: left; background: #f8f9fa; '
-            f'color: #232f3e; padding: 6px 12px;">{label}</th>'
-            f'<td style="padding: 6px 12px; word-break: break-all;">{value}</td></tr>'
-        )
+        return f"<tr><th>{label}</th><td>{value}</td></tr>"
+
+    mtd_card = _render_mtd_card(plan, currency)
 
     rows: list[str] = []
 
@@ -532,10 +796,52 @@ def _render_plan_details(plan: dict[str, Any]) -> str:
         rows.append(_row("Tags", '<em style="color: #6c757d;">none</em>'))
 
     return (
-        '<div class="plan-details-panel" style="background: #fcfcfc; '
-        'padding: 14px 20px; border-left: 3px solid #2196f3;">'
-        '<table style="width: 100%; margin: 0; border-collapse: collapse;">'
+        '<div class="plan-details-panel">'
+        f"{mtd_card}"
+        '<table class="plan-details-kv">'
         "<tbody>" + "".join(rows) + "</tbody></table></div>"
+    )
+
+
+def _render_mtd_card(plan: dict[str, Any], currency: str) -> str:
+    """Month-to-date utilization/savings tiles for one plan.
+
+    Returns an empty string when no MTD data is available (plan just purchased,
+    Cost Explorer still catching up, or the API errored).
+    """
+    mtd_total = plan.get("mtd_total_commitment")
+    if mtd_total is None:
+        return ""
+
+    utilization_pct = plan.get("mtd_utilization_percentage", 0.0) or 0.0
+    net_savings = plan.get("mtd_net_savings", 0.0) or 0.0
+    discount_pct = plan.get("discount_percentage", 0.0) or 0.0
+
+    util_color = (
+        "#28a745" if utilization_pct >= 95 else "#ff9900" if utilization_pct >= 80 else "#dc3545"
+    )
+
+    def _tile(label: str, value: str, color: str = "#232f3e") -> str:
+        return (
+            '<div style="flex: 1; min-width: 140px; background: white; padding: 10px 14px; '
+            'border-radius: 6px; border: 1px solid #e0e0e0;">'
+            f'<div style="font-size: 0.75em; color: #6c757d; text-transform: uppercase; '
+            f'letter-spacing: 0.04em; margin-bottom: 4px;">{label}</div>'
+            f'<div style="font-size: 1.25em; font-weight: 600; color: {color};">{value}</div>'
+            "</div>"
+        )
+
+    tiles = "".join(
+        [
+            _tile("MTD Net Savings", f"{currency} {net_savings:,.2f}", "#28a745"),
+            _tile("MTD Commitment", f"{currency} {mtd_total:,.2f}"),
+            _tile("MTD Utilization", f"{utilization_pct:.1f}%", util_color),
+            _tile("Overall Discount", f"{discount_pct:.1f}%", "#2196f3"),
+        ]
+    )
+    return (
+        '<div style="display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 14px;">'
+        f"{tiles}</div>"
     )
 
 

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -660,12 +660,15 @@ def _build_type_plans_subtable(
                 f'<span class="plan-card-id-short" title="{plan_id}">…{plan_id[-5:]}</span>'
             )
 
+        metrics_html = _render_plan_card_metrics(plan)
+
         items += f"""
                     <div class="plan-card">
                         <div class="{summary_class_attr}" onclick="togglePlanDetails('{details_id}', this)">
                             <span class="plan-toggle-icon">&#9656;</span>
                             <span class="plan-card-commit">${hourly_commitment:.2f}/hr</span>
                             <span class="plan-card-meta">{meta_html}</span>
+                            {metrics_html}
                             {short_id_html}
                             <span class="plan-card-days" title="{tooltip_text}">{days_remaining_display}</span>
                         </div>
@@ -811,6 +814,29 @@ def _render_plan_details(plan: dict[str, Any]) -> str:
         f"{mtd_card}"
         '<table class="plan-details-kv">'
         "<tbody>" + "".join(rows) + "</tbody></table></div>"
+    )
+
+
+def _render_plan_card_metrics(plan: dict[str, Any]) -> str:
+    """Compact MTD utilization + discount pills shown on the folded plan card.
+
+    Returns empty when no MTD data is available (new plans, Cost Explorer lag).
+    """
+    if plan.get("mtd_total_commitment") is None:
+        return ""
+
+    utilization_pct = plan.get("mtd_utilization_percentage", 0.0) or 0.0
+    discount_pct = plan.get("discount_percentage", 0.0) or 0.0
+
+    util_color = (
+        "#28a745" if utilization_pct >= 95 else "#ff9900" if utilization_pct >= 80 else "#dc3545"
+    )
+
+    return (
+        f'<span class="plan-card-pill" style="color: {util_color};" '
+        f'title="MTD utilization">util {utilization_pct:.0f}%</span>'
+        f'<span class="plan-card-pill" style="color: #2196f3;" '
+        f'title="Overall discount rate">disc {discount_pct:.1f}%</span>'
     )
 
 

--- a/lambda/shared/savings_plans_metrics.py
+++ b/lambda/shared/savings_plans_metrics.py
@@ -437,6 +437,90 @@ def get_savings_plans_metrics(
         raise
 
 
+def get_per_plan_mtd_metrics(ce_client: CostExplorerClient) -> dict[str, dict[str, float]]:
+    """Per-plan month-to-date utilization and savings, keyed by Savings Plan ARN.
+
+    Single call to get_savings_plans_utilization_details covering today's
+    month start → today. Returns {} on DataUnavailableException.
+    """
+    now = datetime.now(UTC)
+    start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    params = {
+        "TimePeriod": {
+            "Start": start_of_month.strftime("%Y-%m-%d"),
+            "End": now.strftime("%Y-%m-%d"),
+        },
+    }
+    # If the month just started and end == start, AWS returns an error; widen by 1 day.
+    if params["TimePeriod"]["Start"] == params["TimePeriod"]["End"]:
+        params["TimePeriod"]["End"] = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    logger.info(
+        f"Fetching per-plan MTD metrics from {params['TimePeriod']['Start']} "
+        f"to {params['TimePeriod']['End']}"
+    )
+
+    by_arn: dict[str, dict[str, float]] = {}
+    try:
+        response = ce_client.get_savings_plans_utilization_details(**params)
+        add_response(
+            api="get_savings_plans_utilization_details",
+            params=params,
+            response=response,
+            context="get_per_plan_mtd_metrics",
+        )
+        details = response.get("SavingsPlansUtilizationDetails", [])
+        if not isinstance(details, list):
+            return {}
+
+        for item in details:
+            if not isinstance(item, dict):
+                continue
+            arn = item.get("SavingsPlanArn")
+            if not arn:
+                continue
+            utilization = item.get("Utilization") or {}
+            savings = item.get("Savings") or {}
+            if not isinstance(utilization, dict) or not isinstance(savings, dict):
+                continue
+
+            try:
+                total_commitment = float(utilization.get("TotalCommitment", "0") or 0)
+                used_commitment = float(utilization.get("UsedCommitment", "0") or 0)
+                utilization_pct = float(utilization.get("UtilizationPercentage", "0") or 0)
+                net_savings = float(savings.get("NetSavings", "0") or 0)
+                on_demand_equivalent = float(savings.get("OnDemandCostEquivalent", "0") or 0)
+            except (TypeError, ValueError):
+                continue
+
+            discount_percentage = sp_calculations.calculate_savings_percentage(
+                on_demand_equivalent, used_commitment
+            )
+            by_arn[arn] = {
+                "mtd_total_commitment": total_commitment,
+                "mtd_used_commitment": used_commitment,
+                "mtd_utilization_percentage": utilization_pct,
+                "mtd_net_savings": net_savings,
+                "mtd_on_demand_equivalent": on_demand_equivalent,
+                "discount_percentage": discount_percentage,
+            }
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "DataUnavailableException":
+            logger.info("No per-plan MTD data available yet")
+        else:
+            logger.warning(f"Per-plan MTD fetch failed ({error_code}); skipping per-plan metrics")
+        return {}
+    except Exception as e:
+        # Defensive: any malformed response shape (e.g. test mocks) shouldn't break report gen.
+        logger.warning(f"Per-plan MTD parsing failed ({e!r}); skipping per-plan metrics")
+        return {}
+
+    logger.info(f"Collected MTD metrics for {len(by_arn)} plans")
+    return by_arn
+
+
 def get_savings_plans_summary(
     savingsplans_client: SavingsPlansClient,
     ce_client: CostExplorerClient,

--- a/lambda/shared/savings_plans_metrics.py
+++ b/lambda/shared/savings_plans_metrics.py
@@ -192,24 +192,28 @@ def get_active_savings_plans(
 
         plans_data = []
         for plan in savings_plans:
-            hourly_commitment = float(plan.get("commitment", "0"))
-            plan_type = plan.get("savingsPlanType", "Unknown")
-            plan_id = plan.get("savingsPlanId", "Unknown")
-            start_date = plan.get("start", "Unknown")
-            end_date = plan.get("end", "Unknown")
-            payment_option = plan.get("paymentOption", "Unknown")
             term_seconds = plan.get("termDurationInSeconds", 0)
-            term_years = term_seconds // (365 * 24 * 60 * 60)
-
             plans_data.append(
                 {
-                    "plan_id": plan_id,
-                    "plan_type": plan_type,
-                    "hourly_commitment": hourly_commitment,
-                    "start_date": start_date,
-                    "end_date": end_date,
-                    "payment_option": payment_option,
-                    "term_years": term_years,
+                    "plan_id": plan.get("savingsPlanId", "Unknown"),
+                    "plan_type": plan.get("savingsPlanType", "Unknown"),
+                    "hourly_commitment": float(plan.get("commitment", "0")),
+                    "start_date": plan.get("start", "Unknown"),
+                    "end_date": plan.get("end", "Unknown"),
+                    "payment_option": plan.get("paymentOption", "Unknown"),
+                    "term_years": term_seconds // (365 * 24 * 60 * 60),
+                    # Additional fields for the expandable details panel
+                    "offering_id": plan.get("offeringId", ""),
+                    "savings_plan_arn": plan.get("savingsPlanArn", ""),
+                    "description": plan.get("description", ""),
+                    "state": plan.get("state", ""),
+                    "product_types": plan.get("productTypes", []),
+                    "currency": plan.get("currency", ""),
+                    "upfront_payment_amount": float(plan.get("upfrontPaymentAmount", "0") or 0),
+                    "recurring_payment_amount": float(plan.get("recurringPaymentAmount", "0") or 0),
+                    "term_seconds": term_seconds,
+                    "tags": plan.get("tags", {}),
+                    "returnable_until": plan.get("returnableUntil", ""),
                 }
             )
 


### PR DESCRIPTION
## Summary

Each row in the **Active Plans Details** table of the HTML report is now clickable. Clicking toggles an expanded panel below the row with every useful field returned by `DescribeSavingsPlans`:

- `description` / `state`
- exact start + end timestamps
- `termDurationInSeconds`
- `commitment`, `upfrontPaymentAmount`, `recurringPaymentAmount`
- covered `productTypes` (rendered as chips)
- `returnableUntil` date
- full ARN and `offeringId` (monospace)
- `tags` as a key/value sub-table

## Changes

- `shared/savings_plans_metrics.py` — extend `get_active_savings_plans` to preserve the additional fields (`offering_id`, `savings_plan_arn`, `description`, `state`, `product_types`, `currency`, `upfront_payment_amount`, `recurring_payment_amount`, `term_seconds`, `tags`, `returnable_until`). Fully additive — existing keys and downstream consumers unchanged.
- `reporter/html_sections.py` — two-row rendering (summary row + hidden details row, `<tr hidden>`) with a chevron toggle cell; new `_render_plan_details(plan)` helper.
- `reporter/html_report.py` — CSS for the toggle cell + row hover + chevron rotation, plus a tiny `togglePlanDetails()` vanilla-JS helper.

## Local verification

- `ruff check lambda/` + `ruff format --check lambda/` ✓
- `pytest` in scheduler / purchaser / reporter → 241 passed ✓
- `pytest lambda/tests/test_lambda_packaging.py` → 6 passed ✓
- Generated the report locally and clicked each row — expands/collapses correctly, no console errors, no layout breakage.