### PR TITLE
Fix SonarCloud findings: code smells, complexity, and CI security

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: docs/tests
-        run: npx playwright install --with-deps
+        run: ./node_modules/.bin/playwright install --with-deps
 
       - name: Run Playwright tests
         working-directory: docs/tests

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install ruff
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install --only-binary :all: ruff==0.15.12
 
       - name: Run ruff check
         run: |
@@ -224,9 +224,9 @@ jobs:
       - name: Install all dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r lambda/scheduler/requirements.txt
-          pip install -r lambda/purchaser/requirements.txt
-          pip install -r lambda/reporter/requirements.txt
+          pip install --only-binary :all: -r lambda/scheduler/requirements.txt
+          pip install --only-binary :all: -r lambda/purchaser/requirements.txt
+          pip install --only-binary :all: -r lambda/reporter/requirements.txt
 
       - name: Run all Lambda tests
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Install all dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r lambda/scheduler/requirements.txt
-          pip install -r lambda/purchaser/requirements.txt
-          pip install -r lambda/reporter/requirements.txt
+          pip install --only-binary :all: -r lambda/scheduler/requirements.txt
+          pip install --only-binary :all: -r lambda/purchaser/requirements.txt
+          pip install --only-binary :all: -r lambda/reporter/requirements.txt
 
       - name: Run all Lambda tests with coverage
         env:

--- a/lambda/purchaser/purchase_execution.py
+++ b/lambda/purchaser/purchase_execution.py
@@ -195,6 +195,39 @@ def _sp_type_display(sp_type: str) -> str:
     return sp_type.replace("SavingsPlans", " SP")
 
 
+def _format_successful_purchase(i: int, purchase: dict[str, Any]) -> list[str]:
+    intent = purchase["intent"]
+    sp_id = purchase["sp_id"]
+    offering = intent.get("offering", {})
+    offering_desc = offering.get("description", "") if isinstance(offering, dict) else ""
+
+    result = [
+        f"{i}. {_sp_type_display(intent['sp_type'])}",
+        f"   Savings Plan ID: {sp_id}",
+        f"   Commitment: ${intent['commitment']}/hour",
+        f"   Term: {_term_string(intent['term_seconds'])}",
+        f"   Payment Option: {intent['payment_option']}",
+    ]
+    if offering_desc:
+        result.append(f"   Offering: {offering_desc}")
+    if intent.get("upfront_amount") and float(intent["upfront_amount"]) > 0:
+        result.append(f"   Upfront Payment: ${float(intent['upfront_amount']):,.2f}")
+    if intent.get("strategy"):
+        result.append(f"   Strategy: {intent['strategy']}")
+    if intent.get("estimated_savings_percentage") is not None:
+        result.append(f"   Estimated Savings: {intent['estimated_savings_percentage']}%")
+
+    cov = intent.get("details", {}).get("coverage", {})
+    if cov.get("current") is not None and cov.get("added") is not None:
+        projected = cov["current"] + cov["added"]
+        result.append(
+            f"   Coverage: {cov['current']:.2f}% -> {projected:.2f}% (+{cov['added']:.2f}%)"
+        )
+
+    result.append("")
+    return result
+
+
 def _append_successful_section(lines: list[str], successful: list[dict[str, Any]]) -> None:
     if not successful:
         lines.append("No successful purchases.")
@@ -204,37 +237,7 @@ def _append_successful_section(lines: list[str], successful: list[dict[str, Any]
     lines.append("SUCCESSFUL PURCHASES:")
     lines.append("-" * 60)
     for i, purchase in enumerate(successful, 1):
-        intent = purchase["intent"]
-        sp_id = purchase["sp_id"]
-        offering = intent.get("offering", {})
-        offering_desc = offering.get("description", "") if isinstance(offering, dict) else ""
-
-        lines.extend(
-            [
-                f"{i}. {_sp_type_display(intent['sp_type'])}",
-                f"   Savings Plan ID: {sp_id}",
-                f"   Commitment: ${intent['commitment']}/hour",
-                f"   Term: {_term_string(intent['term_seconds'])}",
-                f"   Payment Option: {intent['payment_option']}",
-            ]
-        )
-        if offering_desc:
-            lines.append(f"   Offering: {offering_desc}")
-        if intent.get("upfront_amount") and float(intent["upfront_amount"]) > 0:
-            lines.append(f"   Upfront Payment: ${float(intent['upfront_amount']):,.2f}")
-        if intent.get("strategy"):
-            lines.append(f"   Strategy: {intent['strategy']}")
-        if intent.get("estimated_savings_percentage") is not None:
-            lines.append(f"   Estimated Savings: {intent['estimated_savings_percentage']}%")
-
-        cov = intent.get("details", {}).get("coverage", {})
-        if cov.get("current") is not None and cov.get("added") is not None:
-            projected = cov["current"] + cov["added"]
-            lines.append(
-                f"   Coverage: {cov['current']:.2f}% -> {projected:.2f}% (+{cov['added']:.2f}%)"
-            )
-
-        lines.append("")
+        lines.extend(_format_successful_purchase(i, purchase))
 
 
 def _append_skipped_section(lines: list[str], skipped: list[dict[str, Any]]) -> None:

--- a/lambda/reporter/html_sections.py
+++ b/lambda/reporter/html_sections.py
@@ -8,6 +8,12 @@ from typing import Any
 from shared import sp_calculations
 
 
+_TABLE_CLOSE = """
+                </tbody>
+            </table>
+"""
+
+
 def build_strategy_tooltip(strategy_key: str, config: dict[str, Any]) -> str:
     """Tooltip shown on each strategy row in the scheduler-preview table."""
     parts = strategy_key.split("+")
@@ -272,10 +278,7 @@ def build_breakdown_table_html(
                     </tr>
 """
 
-    html += """
-                </tbody>
-            </table>
-"""
+    html += _TABLE_CLOSE
     return html
 
 
@@ -452,11 +455,23 @@ def build_active_plans_table_html(plans: list[dict[str, Any]]) -> str:
                     </tr>
 """
 
-    html += """
-                </tbody>
-            </table>
-"""
+    html += _TABLE_CLOSE
     return html
+
+
+_PLAN_TYPE_DISPLAY = {
+    "Compute": "Compute Savings Plans",
+    "SageMaker": "SageMaker Savings Plans",
+    "Database": "Database Savings Plans",
+    "EC2Instance": "EC2 Instance Savings Plans",
+}
+
+
+def _plan_type_display_name(plan_type: str) -> str:
+    for key, display in _PLAN_TYPE_DISPLAY.items():
+        if key in plan_type:
+            return display
+    return plan_type
 
 
 def build_plans_breakdown_section_html(
@@ -510,19 +525,10 @@ def build_plans_breakdown_section_html(
         total_commitment_type = type_data.get("total_commitment", 0.0)
         has_metrics = "average_utilization" in type_data
 
-        if "Compute" in plan_type:
-            plan_type_display = "Compute Savings Plans"
-        elif "SageMaker" in plan_type:
-            plan_type_display = "SageMaker Savings Plans"
-        elif "Database" in plan_type:
-            plan_type_display = "Database Savings Plans"
-        elif "EC2Instance" in plan_type:
-            plan_type_display = "EC2 Instance Savings Plans"
-        else:
-            plan_type_display = plan_type
+        plan_type_display = _plan_type_display_name(plan_type)
 
         type_plans = plans_by_type.get(plan_type, [])
-        next_expiry_cell = _render_next_expiry_cell(type_plans, now, three_months_from_now)
+        next_expiry_cell = _render_next_expiry_cell(type_plans, now)
         next_expiry_days = _next_expiry_days(type_plans, now)
         if next_expiry_days is not None and (
             soonest_overall_days is None or next_expiry_days < soonest_overall_days
@@ -599,10 +605,7 @@ def build_plans_breakdown_section_html(
                     </tr>
 """
 
-    html += """
-                </tbody>
-            </table>
-"""
+    html += _TABLE_CLOSE
     return html
 
 
@@ -712,9 +715,7 @@ def _next_expiry_end(type_plans: list[dict[str, Any]]) -> str:
     return sorted_plans[0].get("end_date", "") or ""
 
 
-def _render_next_expiry_cell(
-    type_plans: list[dict[str, Any]], now: datetime, three_months_from_now: datetime
-) -> str:
+def _render_next_expiry_cell(type_plans: list[dict[str, Any]], now: datetime) -> str:
     """Render the Next Expiry cell for a type row: days + color when <90 days out."""
     days = _next_expiry_days(type_plans, now)
     if days is None:
@@ -736,6 +737,30 @@ def _format_days_cell(days: int, end_date: str) -> str:
         text, color = f"{days} days", "#232f3e"
     tooltip = f"Next plan ends: {end_date.split('T', 1)[0]}" if end_date else ""
     return f'<span title="{tooltip}" style="cursor: help; color: {color};">{text}</span>'
+
+
+def _render_product_chips(product_types: list[str]) -> str:
+    return "".join(
+        f'<span style="display: inline-block; background: #e8eef7; color: #232f3e; '
+        f'padding: 2px 10px; border-radius: 12px; margin: 2px 4px 2px 0; font-size: 0.85em;">'
+        f"{pt}</span>"
+        for pt in product_types
+    )
+
+
+def _render_tags_cell(tags: dict[str, str]) -> str:
+    if not tags:
+        return '<em style="color: #6c757d;">none</em>'
+    tag_rows = "".join(
+        f'<tr><td style="padding: 2px 8px; font-family: monospace; font-size: 0.85em; '
+        f'color: #555;">{k}</td>'
+        f'<td style="padding: 2px 8px; font-family: monospace; font-size: 0.85em;">{v}</td></tr>'
+        for k, v in tags.items()
+    )
+    return (
+        '<table style="width: auto; margin: 0; border-collapse: collapse;">'
+        f"<tbody>{tag_rows}</tbody></table>"
+    )
 
 
 def _render_plan_details(plan: dict[str, Any]) -> str:
@@ -773,44 +798,14 @@ def _render_plan_details(plan: dict[str, Any]) -> str:
     rows.append(_row("Upfront Payment", f"{currency} {upfront:,.2f}"))
     rows.append(_row("Recurring Payment", f"{currency} {recurring:,.5f}/hour"))
     if product_types:
-        chips = "".join(
-            f'<span style="display: inline-block; background: #e8eef7; color: #232f3e; '
-            f'padding: 2px 10px; border-radius: 12px; margin: 2px 4px 2px 0; font-size: 0.85em;">'
-            f"{pt}</span>"
-            for pt in product_types
-        )
-        rows.append(_row("Covered Products", chips))
+        rows.append(_row("Covered Products", _render_product_chips(product_types)))
     if returnable_until:
         rows.append(_row("Returnable Until", returnable_until))
     if savings_plan_arn:
-        rows.append(
-            _row(
-                "ARN",
-                f'<code style="font-size: 0.85em;">{savings_plan_arn}</code>',
-            )
-        )
+        rows.append(_row("ARN", f'<code style="font-size: 0.85em;">{savings_plan_arn}</code>'))
     if offering_id:
-        rows.append(
-            _row(
-                "Offering ID",
-                f'<code style="font-size: 0.85em;">{offering_id}</code>',
-            )
-        )
-
-    if tags:
-        tag_rows = "".join(
-            f'<tr><td style="padding: 2px 8px; font-family: monospace; font-size: 0.85em; '
-            f'color: #555;">{k}</td>'
-            f'<td style="padding: 2px 8px; font-family: monospace; font-size: 0.85em;">{v}</td></tr>'
-            for k, v in tags.items()
-        )
-        tag_table = (
-            '<table style="width: auto; margin: 0; border-collapse: collapse;">'
-            f"<tbody>{tag_rows}</tbody></table>"
-        )
-        rows.append(_row("Tags", tag_table))
-    else:
-        rows.append(_row("Tags", '<em style="color: #6c757d;">none</em>'))
+        rows.append(_row("Offering ID", f'<code style="font-size: 0.85em;">{offering_id}</code>'))
+    rows.append(_row("Tags", _render_tags_cell(tags)))
 
     return (
         '<div class="plan-details-panel">'
@@ -820,14 +815,22 @@ def _render_plan_details(plan: dict[str, Any]) -> str:
     )
 
 
+def _utilization_color(utilization_pct: float) -> str:
+    if utilization_pct >= 95:
+        return "#28a745"
+    if utilization_pct >= 80:
+        return "#ff9900"
+    return "#dc3545"
+
+
 def _expiration_phrase(days_remaining_display: str) -> str:
     """Natural phrasing for the expiration meta chunk on a plan card."""
-    if days_remaining_display in ("Expired", "Today", "N/A"):
-        return (
-            days_remaining_display.lower()
-            if days_remaining_display == "Expired"
-            else ("expires today" if days_remaining_display == "Today" else days_remaining_display)
-        )
+    if days_remaining_display == "Expired":
+        return "expired"
+    if days_remaining_display == "Today":
+        return "expires today"
+    if days_remaining_display == "N/A":
+        return days_remaining_display
     return f"{days_remaining_display} left"
 
 
@@ -843,9 +846,7 @@ def _render_plan_card_metrics(plan: dict[str, Any]) -> str:
     discount_pct = plan.get("discount_percentage", 0.0) or 0.0
     net_savings = plan.get("mtd_net_savings", 0.0) or 0.0
 
-    util_color = (
-        "#28a745" if utilization_pct >= 95 else "#ff9900" if utilization_pct >= 80 else "#dc3545"
-    )
+    util_color = _utilization_color(utilization_pct)
 
     return (
         f'<span class="plan-card-pill" style="color: #28a745;" '
@@ -871,9 +872,7 @@ def _render_mtd_card(plan: dict[str, Any], currency: str) -> str:
     net_savings = plan.get("mtd_net_savings", 0.0) or 0.0
     discount_pct = plan.get("discount_percentage", 0.0) or 0.0
 
-    util_color = (
-        "#28a745" if utilization_pct >= 95 else "#ff9900" if utilization_pct >= 80 else "#dc3545"
-    )
+    util_color = _utilization_color(utilization_pct)
 
     def _tile(label: str, value: str, color: str = "#232f3e") -> str:
         return (

--- a/lambda/reporter/tests/test_html_sections_units.py
+++ b/lambda/reporter/tests/test_html_sections_units.py
@@ -144,11 +144,11 @@ class TestNextExpiryHelpers:
         assert _next_expiry_end([]) == ""
 
     def test_render_next_expiry_cell_none_for_empty(self):
-        assert "N/A" in _render_next_expiry_cell([], _NOW, _THREE_MONTHS)
+        assert "N/A" in _render_next_expiry_cell([], _NOW)
 
     def test_render_next_expiry_cell_renders_days(self):
         plans = [_plan(end_date="2026-06-01T00:00:00Z")]
-        html = _render_next_expiry_cell(plans, _NOW, _THREE_MONTHS)
+        html = _render_next_expiry_cell(plans, _NOW)
         assert "days" in html
         assert "2026-06-01" in html  # tooltip embeds the end date
 

--- a/lambda/shared/config_validation.py
+++ b/lambda/shared/config_validation.py
@@ -121,10 +121,7 @@ def _ensure_dict(config: Any) -> None:
         raise ValueError(f"Configuration must be a dictionary, got {type(config).__name__}")
 
 
-def validate_scheduler_config(config: dict[str, Any]) -> None:
-    _ensure_dict(config)
-    _validate_sp_types_enabled(config)
-
+def _validate_scheduler_numeric_fields(config: dict[str, Any]) -> None:
     for name in ("max_purchase_percent", "min_purchase_percent"):
         if name in config and config[name] is not None:
             _validate_number(config[name], name, min_val=0.0, max_val=100.0)
@@ -147,10 +144,15 @@ def validate_scheduler_config(config: dict[str, Any]) -> None:
             config["purchase_cooldown_days"], "purchase_cooldown_days", min_val=0, integer=True
         )
 
-    _validate_lookback_hours(config)
-
     if "min_commitment_per_plan" in config:
         _validate_number(config["min_commitment_per_plan"], "min_commitment_per_plan", min_val=0)
+
+
+def validate_scheduler_config(config: dict[str, Any]) -> None:
+    _ensure_dict(config)
+    _validate_sp_types_enabled(config)
+    _validate_scheduler_numeric_fields(config)
+    _validate_lookback_hours(config)
 
     for name in ("compute_sp_term", "sagemaker_sp_term"):
         if name in config:

--- a/lambda/shared/savings_plans_metrics.py
+++ b/lambda/shared/savings_plans_metrics.py
@@ -437,6 +437,38 @@ def get_savings_plans_metrics(
         raise
 
 
+def _parse_mtd_detail_item(item: Any) -> tuple[str, dict[str, float]] | None:
+    """Parse a single SavingsPlansUtilizationDetails item into (arn, metrics) or None."""
+    if not isinstance(item, dict):
+        return None
+    arn = item.get("SavingsPlanArn")
+    if not arn:
+        return None
+    utilization = item.get("Utilization") or {}
+    savings = item.get("Savings") or {}
+    if not isinstance(utilization, dict) or not isinstance(savings, dict):
+        return None
+    try:
+        total_commitment = float(utilization.get("TotalCommitment", "0") or 0)
+        used_commitment = float(utilization.get("UsedCommitment", "0") or 0)
+        utilization_pct = float(utilization.get("UtilizationPercentage", "0") or 0)
+        net_savings = float(savings.get("NetSavings", "0") or 0)
+        on_demand_equivalent = float(savings.get("OnDemandCostEquivalent", "0") or 0)
+    except (TypeError, ValueError):
+        return None
+    discount_percentage = sp_calculations.calculate_savings_percentage(
+        on_demand_equivalent, used_commitment
+    )
+    return arn, {
+        "mtd_total_commitment": total_commitment,
+        "mtd_used_commitment": used_commitment,
+        "mtd_utilization_percentage": utilization_pct,
+        "mtd_net_savings": net_savings,
+        "mtd_on_demand_equivalent": on_demand_equivalent,
+        "discount_percentage": discount_percentage,
+    }
+
+
 def get_per_plan_mtd_metrics(ce_client: CostExplorerClient) -> dict[str, dict[str, float]]:
     """Per-plan month-to-date utilization and savings, keyed by Savings Plan ARN.
 
@@ -475,36 +507,10 @@ def get_per_plan_mtd_metrics(ce_client: CostExplorerClient) -> dict[str, dict[st
             return {}
 
         for item in details:
-            if not isinstance(item, dict):
-                continue
-            arn = item.get("SavingsPlanArn")
-            if not arn:
-                continue
-            utilization = item.get("Utilization") or {}
-            savings = item.get("Savings") or {}
-            if not isinstance(utilization, dict) or not isinstance(savings, dict):
-                continue
-
-            try:
-                total_commitment = float(utilization.get("TotalCommitment", "0") or 0)
-                used_commitment = float(utilization.get("UsedCommitment", "0") or 0)
-                utilization_pct = float(utilization.get("UtilizationPercentage", "0") or 0)
-                net_savings = float(savings.get("NetSavings", "0") or 0)
-                on_demand_equivalent = float(savings.get("OnDemandCostEquivalent", "0") or 0)
-            except (TypeError, ValueError):
-                continue
-
-            discount_percentage = sp_calculations.calculate_savings_percentage(
-                on_demand_equivalent, used_commitment
-            )
-            by_arn[arn] = {
-                "mtd_total_commitment": total_commitment,
-                "mtd_used_commitment": used_commitment,
-                "mtd_utilization_percentage": utilization_pct,
-                "mtd_net_savings": net_savings,
-                "mtd_on_demand_equivalent": on_demand_equivalent,
-                "discount_percentage": discount_percentage,
-            }
+            parsed = _parse_mtd_detail_item(item)
+            if parsed:
+                arn, metrics = parsed
+                by_arn[arn] = metrics
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
         if error_code == "DataUnavailableException":


### PR DESCRIPTION
## Summary

- **Python S3358**: Refactored nested ternary expressions in `html_sections.py` into clear if/elif/else blocks and extracted `_utilization_color` helper
- **Python S1192**: Extracted duplicated `</tbody></table>` HTML literal into `_TABLE_CLOSE` constant
- **Python S1172**: Removed unused `three_months_from_now` parameter from `_render_next_expiry_cell`
- **Python S3776**: Reduced cognitive complexity in 5 functions by extracting focused helpers (`_render_product_chips`, `_render_tags_cell`, `_plan_type_display_name`, `_parse_mtd_detail_item`, `_format_successful_purchase`, `_validate_scheduler_numeric_fields`)
- **GHA S8541/S8544**: Added `--only-binary :all:` to pip install commands and pinned ruff version
- **GHA S6505/S8543**: Replaced `npx playwright install` with direct `./node_modules/.bin/playwright install` to avoid version ambiguity and script execution risks

Resolves all 29 open SonarCloud issues.