### PR TITLE
fix(reporter): correct daily chart tooltip total and coverage display

### DIFF
--- a/lambda/reporter/html_report.py
+++ b/lambda/reporter/html_report.py
@@ -1239,21 +1239,29 @@ def generate_html_report(
                                     return label + ' (' + dayName + ')';
                                 }},
                                 footer: function(tooltipItems) {{
-                                    let covered = 0;
+                                    let existing = 0;
+                                    let nextPurchase = 0;
                                     let ondemand = 0;
 
                                     tooltipItems.forEach(function(item) {{
-                                        if (item.dataset.label.includes('Commitment') || item.dataset.label.includes('next purchase')) {{
-                                            covered = item.parsed.y;
+                                        if (item.dataset.label.includes('next purchase')) {{
+                                            nextPurchase = item.parsed.y;
+                                        }} else if (item.dataset.label.includes('Commitment')) {{
+                                            existing = item.parsed.y;
                                         }} else {{
                                             ondemand = item.parsed.y;
                                         }}
                                     }});
 
-                                    const total = covered + ondemand;
-                                    const coveragePercent = total > 0 ? (covered / total * 100).toFixed(1) : 0;
+                                    const total = existing + nextPurchase + ondemand;
+                                    const currentPct = total > 0 ? (existing / total * 100).toFixed(1) : '0.0';
+                                    const nextPct = total > 0 ? (nextPurchase / total * 100).toFixed(1) : '0.0';
+                                    let coverage = 'Coverage: ' + currentPct + '%';
+                                    if (nextPurchase > 0) {{
+                                        coverage += ' + ' + nextPct + '%';
+                                    }}
 
-                                    return 'Total: $' + total.toFixed(2) + '\\nCoverage: ' + coveragePercent + '%';
+                                    return 'Total: $' + total.toFixed(2) + '\\n' + coverage;
                                 }}
                             }}
                         }},
@@ -1389,18 +1397,26 @@ def generate_html_report(
                                     return yy + '-' + mm + '-' + dd + ' (' + dayName + ')';
                                 }},
                                 footer: function(tooltipItems) {{
-                                    let covered = 0;
+                                    let existing = 0;
+                                    let nextPurchase = 0;
                                     let ondemand = 0;
                                     tooltipItems.forEach(function(item) {{
-                                        if (item.dataset.label.includes('Commitment') || item.dataset.label.includes('next purchase')) {{
-                                            covered = item.parsed.y;
+                                        if (item.dataset.label.includes('next purchase')) {{
+                                            nextPurchase = item.parsed.y;
+                                        }} else if (item.dataset.label.includes('Commitment')) {{
+                                            existing = item.parsed.y;
                                         }} else {{
                                             ondemand = item.parsed.y;
                                         }}
                                     }});
-                                    const total = covered + ondemand;
-                                    const coveragePercent = total > 0 ? (covered / total * 100).toFixed(1) : 0;
-                                    return 'Total: $' + total.toFixed(2) + '\\nCoverage: ' + coveragePercent + '%';
+                                    const total = existing + nextPurchase + ondemand;
+                                    const currentPct = total > 0 ? (existing / total * 100).toFixed(1) : '0.0';
+                                    const nextPct = total > 0 ? (nextPurchase / total * 100).toFixed(1) : '0.0';
+                                    let coverage = 'Coverage: ' + currentPct + '%';
+                                    if (nextPurchase > 0) {{
+                                        coverage += ' + ' + nextPct + '%';
+                                    }}
+                                    return 'Total: $' + total.toFixed(2) + '\\n' + coverage;
                                 }}
                             }}
                         }}


### PR DESCRIPTION
## Problem

The "Daily Usage" chart tooltip dropped the existing Savings Plan commitment from its **Total** and **Coverage** figures.

In the `footer` callback (two copies, one per daily chart) the covered amount was assigned rather than accumulated:

```js
if (label.includes('Commitment') || label.includes('next purchase')) {
    covered = item.parsed.y;   // overwrites instead of summing
}
```

Iterating the three datasets, `covered` ends up holding only the last match ("Added by next purchase") and discards "Existing SP Commitment".

Example, 2026-06-18 (424.62 existing + 35.42 next purchase + 139.85 on-demand):

| | Total | Coverage |
|---|---|---|
| Shown | `$175.27` | `20.2%` |
| Correct | `$599.89` | `76.7%` |

## Fix

Track existing commitment, next purchase and on-demand separately:

- **Total** sums all three bands.
- **Coverage** is shown as `current% + next_purchase%` (e.g. `70.8% + 5.9%`) so the scheduler's projected gain is explicit. It falls back to `current%` when no next purchase is scheduled.

Applied to both daily charts (global/compute and database/sagemaker). The chart bars were already drawn correctly; only the hover readout changed.

All 58 reporter unit tests pass.
